### PR TITLE
add aarch64 support

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -21,6 +21,9 @@ install_restic () {
     armv*)
       arch=arm
       ;;
+     aarch64)
+      arch=arm64
+      ;;
     *)
       echo
       ynh_die --message="Unsupported architecture \"$architecture\""


### PR DESCRIPTION
# Problem
In using a rockpro with 64bits armbian. 
installation of restic fails with error aarch64 not supported.

# Solution 
add aarch64 detection and download the corresponding binary.