### PR TITLE
improve right management

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -55,6 +55,7 @@ cat > /tmp/${app}_sudoer << EOSUDOER
 ${app} ALL = (root) NOPASSWD: /usr/bin/yunohost*, /bin/journalctl*, /usr/bin/find /etc/yunohost/apps -name backup, ${final_path}/check_method_${app}
 EOSUDOER
 visudo -cf /tmp/${app}_sudoer && mv /tmp/${app}_sudoer /etc/sudoers.d/${app}
+chmod 644 /etc/sudoers.d/${app}
 
 #=================================================
 # ACTIVATE BACKUP METHODS
@@ -156,6 +157,7 @@ Host ${server}
   UserKnownHostsFile /dev/null
 # end $app ssh config
 EOCONF
+chmod 700 ${ssh_dir}/config
 
 #=================================================
 # Display key

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -76,6 +76,7 @@ cat > /tmp/${app}_sudoer << EOSUDOER
 ${app} ALL = (root) NOPASSWD: /usr/bin/yunohost*, /bin/journalctl*, /usr/bin/find /etc/yunohost/apps -name backup, ${final_path}/check_method_${app}
 EOSUDOER
 visudo -cf /tmp/${app}_sudoer && mv /tmp/${app}_sudoer /etc/sudoers.d/${app}
+chmod 644 /etc/sudoers.d/${app}
 ynh_script_progression --message="Move ssh keys from root to ${app} user's home"
 ynh_script_progression --message="Generate ssh config"
 set +o errexit
@@ -98,6 +99,7 @@ if [ "$missing_conf" -eq "1" ];then
     UserKnownHostsFile /dev/null
   # end $app ssh config
 EOCONF
+chmod 700 ${ssh_dir}/config
 fi
 chown -R ${app}: /home/${app}
 


### PR DESCRIPTION
## Problem

- Installing restic on a fresh yunohost with no app installed, it run into error due to wrong permission for `/etc/sudoers.d/restic` and `/root/.ssh/config` files.

## Solution

- I change permission for the following files : 
```
chmod 644 /etc/sudoers.d/restic
chomd 700 /root/.ssh/config
```

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
