### PR TITLE
add yunohost error detection

### DIFF
--- a/conf/restic_log.j2
+++ b/conf/restic_log.j2
@@ -4,6 +4,20 @@ set -u
 invocation_id=$(systemctl show -p InvocationID --value {{ app }}.service)
 hostname=$(hostname)
 subject="YunoHost Restic backup log on ${hostname}"
+
+
+sudo /bin/journalctl _SYSTEMD_INVOCATION_ID=${invocation_id} | grep "The operation '.*' could not be completed."
+if [ "$?" -eq 0 ];then
+  yuno_log_name=$(sudo /bin/journalctl -u {{ app }} | grep -oP "[0-9]{8}-[0-9]{6}-[^']+")
+  sudo /bin/journalctl _SYSTEMD_INVOCATION_ID=${invocation_id} > /tmp/journalctl.log
+  subject="[ERROR] Unexpected error during Yunohost Restic backup"
+  body="an unexpected error occured during backup please find attached journalctl. \
+  You can also look at yunohost logs ($yuno_log_name) or with the following command line : yunohost logs show $yuno_log_name"
+  echo "$body" | mail -s "$subject" -A /tmp/journalctl.log root
+  rm /tmp/journalctl.log
+  exit 1
+fi
+
 backup_results=$(sudo /bin/journalctl _SYSTEMD_INVOCATION_ID=${invocation_id} | grep -oP '(?<=    )[a-zA-Z_-]+: \w+')
 echo ${backup_results} | grep -iqE 'error|fail'
 if [ "$?" -eq 0 ];then


### PR DESCRIPTION
## Problem

- I configure backup that were working properly for month. When I tried to add new app to backup, I realized that my backup were successfull locally but were never pushed to remote server due to misconfiguration. This PR try to remediate to this by tracking log relative to yunohost error

## Solution

- Look for 'The operation '.*' could not be completed' sentence that who means that something wrong append in yunohost part.
- Then send an email to say that something wrong append and give some debug information.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
