### PR TITLE
Restic update + Autoupdate + Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Regularly create encrypted backups sent to another server using Restic
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://restic.net)
-[![Version: 0.18.0~ynh3](https://img.shields.io/badge/Version-0.18.0~ynh3-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/restic/)
+[![Version: 0.18.1~ynh1](https://img.shields.io/badge/Version-0.18.1~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/restic/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/restic"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -1,9 +1,11 @@
 A [Restic](https://restic.net/) integration to backup your YunoHost server to an external location.
 
 ### Features
+- **Multiple storage backends**: Supports all Restic storage types (SFTP, S3, Backblaze B2, Azure, etc.). **SFTP is recommended** for simplicity.
+- **Deduplication and compression**: Saves space by removing duplicates and compressing data.
+- **Encryption**: Data is encrypted before being sent to the storage backend.
+- **Flexibility**: Install multiple instances to backup to different locations or set custom frequencies.
 
-- backup data to remote storages (support for different types of storage: currently SFTP, S3 is planned)
-- deduplication and compression of files, which makes it possible to keep many previous copies
-- data encryption, which allows to store data at a third party
-
-You can setup the Restic app several times on the same server so you can backup on several server or manage your frequency backup differently for specific part of your server.
+### Configuration
+- **SFTP**: Configure directly during installation.
+- **Other backends**: Set the required environment variables in the **App Panel** after installation.

--- a/manifest.toml
+++ b/manifest.toml
@@ -34,8 +34,8 @@ ram.runtime = "50M"
     [install.repository]
     ask.en = "In which location do you want to backup your files?"
     ask.fr = "Dans quel endroit souhaitez-vous sauvegarder vos fichiers ?"
-    help.fr = "Spécifiez un serveur SFTP (`sftp:user@host:port//srv/restic-repo`) ou tout autre format de `--repo` supporté par Restic (voir https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html, vous devrez ajouter des variables d'environnement manuellement)"
-    help.en = "Specify a SFTP server (`sftp:user@host:port//srv/restic-repo`) or any other repository format supported by Restic (see https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html, you'll need to add environment variables manually)"
+    help.fr = "Spécifiez un serveur SFTP (`sftp://user@host:port//srv/restic-repo`) ou tout autre format de `--repo` supporté par Restic (voir https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html, vous devrez ajouter des variables d'environnement manuellement)"
+    help.en = "Specify a SFTP server (`sftp://user@host:port//srv/restic-repo`) or any other repository format supported by Restic (see https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html, you'll need to add environment variables manually)"
     type = "string"
     example = "sftp://john@serverb.tld:22//backups"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Restic"
 description.en = "Regularly create encrypted backups sent to another server using Restic"
 description.fr = "Créez régulièrement des sauvegardes chiffrées envoyées sur un autre serveur avec Restic"
 
-version = "0.18.0~ynh3"
+version = "0.18.1~ynh1"
 
 maintainers = ["Gildas-GH"]
 
@@ -75,14 +75,14 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    amd64.url = "https://github.com/restic/restic/releases/download/v0.18.0/restic_0.18.0_linux_amd64.bz2"
-    amd64.sha256 = "98f6dd8bf5b59058d04bfd8dab58e196cc2a680666ccee90275a3b722374438e"
-    i386.url = "https://github.com/restic/restic/releases/download/v0.18.0/restic_0.18.0_linux_386.bz2"
-    i386.sha256 = "c171b288885830863fa290a3bcdc4e50c0425758f3fff7ce7fef27741b0cf374"
-    arm64.url = "https://github.com/restic/restic/releases/download/v0.18.0/restic_0.18.0_linux_arm64.bz2"
-    arm64.sha256 = "ce18179c25dc5f2e33e3c233ba1e580f9de1a4566d2977e8d9600210363ec209"
-    armhf.url = "https://github.com/restic/restic/releases/download/v0.18.0/restic_0.18.0_linux_arm.bz2"
-    armhf.sha256 = "a202b58cb23c7b40e2562d9b0804492f77278bd0d0bf043f5e02951f89c83eb5"
+    amd64.url = "https://github.com/restic/restic/releases/download/v0.18.1/restic_0.18.1_linux_amd64.bz2"
+    amd64.sha256 = "680838f19d67151adba227e1570cdd8af12c19cf1735783ed1ba928bc41f363d"
+    i386.url = "https://github.com/restic/restic/releases/download/v0.18.1/restic_0.18.1_linux_386.bz2"
+    i386.sha256 = "b6c4b3dc507ac8df840b5611ada36134fa2208a2941be3376096137712659f81"
+    arm64.url = "https://github.com/restic/restic/releases/download/v0.18.1/restic_0.18.1_linux_arm64.bz2"
+    arm64.sha256 = "87f53fddde38764095e9c058a3b31834052c37e5826d2acf34e18923c006bd45"
+    armhf.url = "https://github.com/restic/restic/releases/download/v0.18.1/restic_0.18.1_linux_arm.bz2"
+    armhf.sha256 = "1ead22ca3b123f11cd1ce74ba4079c324aa616efb25227c715471420a1c2a364"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.amd64 = ".*linux_amd64.bz2"

--- a/manifest.toml
+++ b/manifest.toml
@@ -18,7 +18,7 @@ admindoc = "https://restic.readthedocs.io/en/latest/"
 code = "https://github.com/restic/restic"
 
 [integration]
-yunohost = ">= 12.0.9"
+yunohost = ">= 12.1.17"
 helpers_version = "2.1"
 architectures = "all"
 multi_instance = true

--- a/manifest.toml
+++ b/manifest.toml
@@ -88,7 +88,7 @@ ram.runtime = "50M"
     autoupdate.asset.amd64 = ".*linux_amd64.bz2"
     autoupdate.asset.i386 = ".*linux_386.bz2"
     autoupdate.asset.arm64 = ".*linux_arm64.bz2"
-    autoupdate.asset.armf = ".*linux_arm.bz2"
+    autoupdate.asset.armhf = ".*linux_arm.bz2"
 
     in_subdir = false
     rename = "restic.bz2"

--- a/manifest.toml
+++ b/manifest.toml
@@ -84,6 +84,12 @@ ram.runtime = "50M"
     armhf.url = "https://github.com/restic/restic/releases/download/v0.18.0/restic_0.18.0_linux_arm.bz2"
     armhf.sha256 = "a202b58cb23c7b40e2562d9b0804492f77278bd0d0bf043f5e02951f89c83eb5"
 
+    autoupdate.strategy = "latest_github_release"
+    autoupdate.asset.amd64 = ".*linux_amd64.bz2"
+    autoupdate.asset.i386 = ".*linux_386.bz2"
+    autoupdate.asset.arm64 = ".*linux_arm64.bz2"
+    autoupdate.asset.armf = ".*linux_arm.bz2"
+
     in_subdir = false
     rename = "restic.bz2"
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -10,9 +10,7 @@ ynh_script_progression "Removing system configurations related to $app..."
 
 # Systemd services and timers
 for suffix in "${systemd_services_suffixes[@]}"; do
-    if ynh_hide_warnings yunohost service status "$app_suffix" >/dev/null; then
-        yunohost service remove "$app_suffix"
-    fi
+    yunohost service remove "$app$suffix"
     ynh_systemctl --service="$app$suffix.timer" --action="stop"
     ynh_systemctl --service="$app$suffix.timer" --action="disable"
     ynh_config_remove_systemd "$app$suffix"


### PR DESCRIPTION
- Update Restic to 0.18.1 by @CodeShakingSheep 
- Add autoupdate strategy by @CodeShakingSheep
- Remove services from YunoHost service list when uninstalling the app (close #41)
- Fix helper text for the Repository field
- Update app description to explain S3 usage

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
