### PR TITLE
New features and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Regularly create encrypted backups sent to another server using Restic
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://restic.net)
-[![Version: 0.18.1~ynh1](https://img.shields.io/badge/Version-0.18.1~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/restic/)
+[![Version: 0.18.1~ynh2](https://img.shields.io/badge/Version-0.18.1~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/restic/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/restic"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/backup-with-restic
+++ b/conf/backup-with-restic
@@ -3,11 +3,10 @@
 errors=""
 current_date=$(date +"%y%m%d_%H%M")
 log_file="/var/log/__APP__/${current_date}.log"
-err_file="/var/log/__APP__/${current_date}.err"
 mkdir -p "/var/log/__APP__"
 
 filter_hooks() {
-    ls /usr/share/yunohost/hooks/backup/ | grep "\-$1_" | cut -d"-" -f2 | uniq 2>> "$err_file"
+    ls /usr/share/yunohost/hooks/backup/ | grep "\-$1_" | cut -d"-" -f2 | uniq 2>&1
 }
 
 sudo yunohost app setting __APP__ last_run -v "${current_date}"
@@ -20,7 +19,7 @@ export BACKUP_CORE_ONLY
 # Backup system part conf
 conf=$(sudo yunohost app setting __APP__ conf)
 if [[ "$conf" = "1" ]]; then
-    if ! sudo yunohost backup create -n auto_conf --method __APP___app --system $(filter_hooks conf) 2>> "$err_file" >> "$log_file" ; then
+    if ! sudo yunohost backup create -n auto_conf --method __APP___app --system $(filter_hooks conf) >> "$log_file" 2>&1 ; then
         errors+="\nThe backup miserably failed to backup system configurations."
     fi
 fi
@@ -28,7 +27,7 @@ fi
 # Backup system data
 data=$(sudo yunohost app setting __APP__ data)
 if [[ "$data" = "1" ]]; then
-    if ! sudo yunohost backup create -n auto_data --method __APP___app --system $(filter_hooks data) 2>> "$err_file" >> "$log_file" ; then
+    if ! sudo yunohost backup create -n auto_data --method __APP___app --system $(filter_hooks data) >> "$log_file" 2>&1 ; then
         errors+="\nThe backup miserably failed to backup system data."
     fi
 fi
@@ -83,16 +82,16 @@ for application in $(sudo ls /etc/yunohost/apps/); do
     fi
 
     # Execute backup
-    if ! sudo yunohost backup create -n "auto_$application" --method __APP___app --apps "$application" 2>> "$err_file" >> "$log_file"; then
+    if ! sudo yunohost backup create -n "auto_$application" --method __APP___app --apps "$application" >> "$log_file" 2>&1; then
         errors+="\nThe backup miserably failed to backup $application application."
     fi
 done
 
 #=============================================
-# SEND MAIL TO NOTIFY ABOUT  FAILED OPERATIONS
+# SEND MAIL TO NOTIFY ABOUT FAILED OPERATIONS
 #=============================================
 
-partial_errors="$(cat "$log_file" | grep -E "Error|Skipped")"
+partial_errors="$(grep -iE "Error|Skipped|Warning|Fatal|Fail" "$log_file")"
 if [ -n "$partial_errors" ]; then
     errors+="\nSome backup partially failed:\n$partial_errors"
 fi
@@ -102,7 +101,7 @@ domain=$(hostname)
 repository="$(sudo yunohost app setting __APP__ repository)"
 if [[ -n "$errors" ]]; then
     sudo yunohost app setting __APP__ state -v "failed"
-    cat <(echo -e "$errors\n\n\n") "$log_file" "$err_file" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[__APP__] Backup failed from $domain onto $repository" root
+    echo -e "$errors\n\n\n$(cat "$log_file")" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[__APP__] Backup failed from $domain onto $repository" root
 else
     sudo yunohost app setting __APP__ state -v "successful"
 fi

--- a/conf/backup-with-restic
+++ b/conf/backup-with-restic
@@ -13,6 +13,10 @@ filter_hooks() {
 sudo yunohost app setting __APP__ last_run -v "${current_date}"
 sudo yunohost app setting __APP__ state -v "ongoing"
 
+BACKUP_CORE_ONLY=$(sudo yunohost app setting __APP__ backup_core_only)
+
+export BACKUP_CORE_ONLY
+
 # Backup system part conf
 conf=$(sudo yunohost app setting __APP__ conf)
 if [[ "$conf" = "1" ]]; then

--- a/conf/backup-with-restic
+++ b/conf/backup-with-restic
@@ -35,20 +35,51 @@ fi
 apps=$(sudo yunohost app setting __APP__ apps | sed 's/,[[:space:]]*/,/g')
 apps="${apps//,/ }"
 
-for application in $(sudo ls /etc/yunohost/apps/); do
+# Initialisation
+include_all=false
+exclude_list=()
+explicit_include_list=()
 
-    if ( [[ "$apps" =~ ^exclude: ]] && grep -wq "$application" <<< "$apps" ) ||
-       ( [[ "$apps" != "all" ]] && [[ ! "$apps" =~ ^exclude: ]]  && ! grep -wq "$application" <<< "$apps" );
-    then
-        continue
+# Parse app list
+for item in $apps; do
+    if [[ "$item" == "all" ]]; then
+        include_all=true
+    elif [[ "$item" =~ ^exclude: ]]; then
+        exclude_list+=("${item#exclude:}")
+    else
+        # If you are not in "all" mode, add to the explicit inclusion list
+        if ! $include_all; then
+            explicit_include_list+=("$item")
+        # If you are in "all" mode and the element is not prefixed with "exclude:", it is an implicit exclusion.
+        else
+            exclude_list+=("$item")
+        fi
+    fi
+done
+
+# Loop on applications
+for application in $(sudo ls /etc/yunohost/apps/); do
+    # Exclude/Include logic
+    if $include_all; then
+        # "All" mode: those in exclude_list are excluded.
+        if printf '%s\n' "${exclude_list[@]}" | grep -q "^${application}\$"; then
+            continue
+        fi
+    else
+        # Explicit inclusion mode: only those in explicit_include_list are included.
+        if ! printf '%s\n' "${explicit_include_list[@]}" | grep -q "^${application}\$"; then
+            continue
+        fi
     fi
 
-    if sudo test ! -f "/etc/yunohost/apps/$application/scripts/backup" ; then
+    # Verify backup script
+    if sudo test ! -f "/etc/yunohost/apps/$application/scripts/backup"; then
         errors+="\nWarning: The application $application has no backup script. This app won't be backed up."
         continue
     fi
 
-    if ! sudo yunohost backup create -n "auto_$application" --method __APP___app --apps $application 2>> "$err_file" >> "$log_file" ; then
+    # Execute backup
+    if ! sudo yunohost backup create -n "auto_$application" --method __APP___app --apps "$application" 2>> "$err_file" >> "$log_file"; then
         errors+="\nThe backup miserably failed to backup $application application."
     fi
 done

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -9,6 +9,7 @@ set -euo pipefail
 ###
 RESTIC_REPOSITORY_BASE=$(yunohost app setting __APP__ repository)
 RESTIC_PASSWORD=$(ynh_app_setting_get --app=__APP__ --key=passphrase)
+HOME="/root"
 
 RESTIC_COMMAND=__INSTALL_DIR__/restic
 
@@ -48,6 +49,7 @@ do_need_mount() {
 
     export RESTIC_PASSWORD
     export RESTIC_REPOSITORY=${RESTIC_REPOSITORY_BASE}/$name
+    export HOME
 
     load_env_file
     load_ssh_agent
@@ -70,6 +72,8 @@ do_backup() {
 
     export RESTIC_PASSWORD
     export RESTIC_REPOSITORY=${RESTIC_REPOSITORY_BASE}/$name
+    export HOME
+    
     local current_date
     current_date=$(date +"%d_%m_%y_%H:%M")
     load_env_file

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -8,7 +8,8 @@ set -euo pipefail
 # Fetch information from YNH settings
 ###
 RESTIC_REPOSITORY_BASE=$(yunohost app setting __APP__ repository)
-RESTIC_PASSWORD=$(ynh_app_setting_get --app=__APP__ --key=passphrase)
+password=$(ynh_app_setting_get --app=__APP__ --key=passphrase)
+RESTIC_PASSWORD=$password
 HOME="/root"
 
 RESTIC_COMMAND=__INSTALL_DIR__/restic
@@ -73,7 +74,7 @@ do_backup() {
     export RESTIC_PASSWORD
     export RESTIC_REPOSITORY=${RESTIC_REPOSITORY_BASE}/$name
     export HOME
-    
+
     local current_date
     current_date=$(date +"%d_%m_%y_%H:%M")
     load_env_file

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -18,7 +18,7 @@ load_env_file() {
   local env_file="__INSTALL_DIR__/.env"
   if [ -f "$env_file" ]; then
     set -o allexport
-    source "$env_file" || { ynh_print_warn "Erreur : Impossible de charger le fichier d'environnement $env_file" >&2; exit 1; }
+    source "$env_file" || { ynh_print_warn "Failed to load environment variables file ($env_file)" >&2; exit 1; }
     set +o allexport
   fi
 }
@@ -28,15 +28,16 @@ load_ssh_agent() {
 
   # Verify if ssh-agent is running, start it otherwise
   if [ -z "${SSH_AGENT_PID:-}" ] || ! ps -p "$SSH_AGENT_PID" > /dev/null 2>&1; then
-    eval "$(ssh-agent -s)" || { ynh_print_warn "Erreur : Impossible de démarrer ssh-agent" >&2; exit 1; }
+    eval "$(ssh-agent -s)"
   fi
 
   # Verify if SSH key is already added
   if ! ssh-add -l | grep -q "$(basename "$ssh_key")"; then
     if [ -f "$ssh_key" ]; then
-      ssh-add "$ssh_key" > /dev/null 2>&1 || ynh_print_warn "Erreur : Impossible d'ajouter la clé SSH $ssh_key" >&2
+      if ! ssh-add -q "$ssh_key" >&2; then
+        ynh_print_warn "Failed to add SSH key to agent ($ssh_key)" >&2
     else
-      ynh_print_warn "Erreur : Clé SSH $ssh_key introuvable" >&2
+      ynh_print_warn "Failed to find SSH key ($ssh_key)" >&2
     fi
   fi
   trap 'ssh-agent -k > /dev/null' EXIT
@@ -56,12 +57,12 @@ do_need_mount() {
     load_ssh_agent
 
     if ! $RESTIC_COMMAND cat config > /dev/null 2>&1; then
-      ynh_print_info "Dépôt non initialisé, initialisation en cours..."
-      if ! $RESTIC_COMMAND init >&2; then
-        ynh_print_warn "Erreur : Échec de l'initialisation du dépôt Restic" >&2
+      ynh_print_info "The Restic repository isn't initialized yet"
+      if ! $RESTIC_COMMAND init -q >&2; then
+        ynh_print_warn "Failed to initialize the new Restic repository" >&2
         exit 1
       fi
-      ynh_print_info "Dépôt initialisé avec succès" >&2
+      ynh_print_info "The Restic repository was successfuly initialized" >&2
     fi
 }
 
@@ -81,14 +82,14 @@ do_backup() {
     load_ssh_agent
     pushd "$work_dir" > /dev/null
 
-    if ! $RESTIC_COMMAND backup ./ >&2; then
-      ynh_print_warn "Erreur : Échec de la sauvegarde Restic" >&2
+    if ! $RESTIC_COMMAND backup -q ./ >&2; then
+      ynh_print_warn "Failed to upload backup with Restic"
       exit 1
     fi
 
     local forget_policy="$(yunohost app setting __APP__ forget_policy)"
-    if ! $RESTIC_COMMAND forget $forget_policy >&2; then
-      ynh_print_warn "Erreur : Échec de l'application de la politique de rétention" >&2
+    if ! $RESTIC_COMMAND forget -q $forget_policy >&2; then
+      ynh_print_warn "Failed to apply backup retention policy"
       exit 1
     fi
     popd > /dev/null
@@ -110,7 +111,7 @@ case "$1" in
     do_need_mount "$work_dir" "$name" "$size" "$description"
     ;;
   *)
-    ynh_print_warn "Erreur : Argument inconnu \`$1'" >&2
+    ynh_print_warn "Unknown argument \`$1'" >&2
     exit 1
     ;;
 esac

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -36,6 +36,7 @@ load_ssh_agent() {
     if [ -f "$ssh_key" ]; then
       if ! ssh-add -q "$ssh_key" >&2; then
         ynh_print_warn "Failed to add SSH key to agent ($ssh_key)" >&2
+      fi
     else
       ynh_print_warn "Failed to find SSH key ($ssh_key)" >&2
     fi

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -8,17 +8,15 @@ set -euo pipefail
 # Fetch information from YNH settings
 ###
 RESTIC_REPOSITORY_BASE=$(yunohost app setting __APP__ repository)
-RESTIC_PASSWORD="$(yunohost app setting __APP__ passphrase)"
+RESTIC_PASSWORD=$(ynh_app_setting_get --app=__APP__ --key=passphrase)
 
 RESTIC_COMMAND=__INSTALL_DIR__/restic
-LOGFILE=/var/log/__APP__/backup.log
-ERRFILE=/var/log/__APP__/backup-error.log
 
 load_env_file() {
   local env_file="__INSTALL_DIR__/.env"
   if [ -f "$env_file" ]; then
     set -o allexport
-    source "$env_file" || { echo "Erreur : Impossible de charger le fichier d'environnement $env_file" >&2; exit 1; }
+    source "$env_file" || { ynh_print_warn "Erreur : Impossible de charger le fichier d'environnement $env_file" >&2; exit 1; }
     set +o allexport
   fi
 }
@@ -28,15 +26,15 @@ load_ssh_agent() {
 
   # Verify if ssh-agent is running, start it otherwise
   if [ -z "${SSH_AGENT_PID:-}" ] || ! ps -p "$SSH_AGENT_PID" > /dev/null 2>&1; then
-    eval "$(ssh-agent -s)" || { echo "Erreur : Impossible de démarrer ssh-agent" >&2; exit 1; }
+    eval "$(ssh-agent -s)" || { ynh_print_warn "Erreur : Impossible de démarrer ssh-agent" >&2; exit 1; }
   fi
 
   # Verify if SSH key is already added
   if ! ssh-add -l | grep -q "$(basename "$ssh_key")"; then
     if [ -f "$ssh_key" ]; then
-      ssh-add "$ssh_key" > /dev/null 2>&1 || echo "Erreur : Impossible d'ajouter la clé SSH $ssh_key" >&2
+      ssh-add "$ssh_key" > /dev/null 2>&1 || ynh_print_warn "Erreur : Impossible d'ajouter la clé SSH $ssh_key" >&2
     else
-      echo "Erreur : Clé SSH $ssh_key introuvable" >&2
+      ynh_print_warn "Erreur : Clé SSH $ssh_key introuvable" >&2
     fi
   fi
   trap 'ssh-agent -k > /dev/null' EXIT
@@ -54,19 +52,13 @@ do_need_mount() {
     load_env_file
     load_ssh_agent
 
-    # Check if a repository is already initialized, else init
-    echo "Vérification de l'initialisation du dépôt Restic..."
-    ynh_print_info "Vérification de l'initialisation du dépôt Restic..."
-
-    if $RESTIC_COMMAND cat config > /dev/null 2>&1; then
-      echo "Dépôt déjà initialisé" >&2
-    else
-      echo "Dépôt non initialisé, initialisation en cours..."
+    if ! $RESTIC_COMMAND cat config > /dev/null 2>&1; then
+      ynh_print_info "Dépôt non initialisé, initialisation en cours..."
       if ! $RESTIC_COMMAND init >&2; then
-        echo "Erreur : Échec de l'initialisation du dépôt Restic" >&2
+        ynh_print_warn "Erreur : Échec de l'initialisation du dépôt Restic" >&2
         exit 1
       fi
-      echo "Dépôt initialisé avec succès" >&2
+      ynh_print_info "Dépôt initialisé avec succès" >&2
     fi
 }
 
@@ -84,19 +76,16 @@ do_backup() {
     load_ssh_agent
     pushd "$work_dir" > /dev/null
 
-    echo "Lancement de la sauvegarde..."
     if ! $RESTIC_COMMAND backup ./ >&2; then
-      echo "Erreur : Échec de la sauvegarde Restic" >&2
+      ynh_print_warn "Erreur : Échec de la sauvegarde Restic" >&2
       exit 1
     fi
 
-    echo "Sauvegarde réussie, application de la politique de rétention..."
     local forget_policy="$(yunohost app setting __APP__ forget_policy)"
     if ! $RESTIC_COMMAND forget $forget_policy >&2; then
-      echo "Erreur : Échec de l'application de la politique de rétention" >&2
+      ynh_print_warn "Erreur : Échec de l'application de la politique de rétention" >&2
       exit 1
     fi
-    echo "Politique de rétention appliquée : $forget_policy" >&2
     popd > /dev/null
 }
 
@@ -116,7 +105,7 @@ case "$1" in
     do_need_mount "$work_dir" "$name" "$size" "$description"
     ;;
   *)
-    echo "Erreur : Argument inconnu \`$1'" >&2
+    ynh_print_warn "Erreur : Argument inconnu \`$1'" >&2
     exit 1
     ;;
 esac

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /usr/share/yunohost/helpers
+
 set -euo pipefail
 
 ###
@@ -16,7 +18,7 @@ load_env_file() {
   local env_file="__INSTALL_DIR__/.env"
   if [ -f "$env_file" ]; then
     set -o allexport
-    source "$env_file"
+    source "$env_file" || { echo "Erreur : Impossible de charger le fichier d'environnement $env_file" >&2; exit 1; }
     set +o allexport
   fi
 }
@@ -24,15 +26,17 @@ load_env_file() {
 load_ssh_agent() {
   local ssh_key="/root/.ssh/id___APP___ed25519"
 
-  # Verify if ssh-agend is running, start it otherwise
+  # Verify if ssh-agent is running, start it otherwise
   if [ -z "${SSH_AGENT_PID:-}" ] || ! ps -p "$SSH_AGENT_PID" > /dev/null 2>&1; then
-    eval "$(ssh-agent -s)"
+    eval "$(ssh-agent -s)" || { echo "Erreur : Impossible de démarrer ssh-agent" >&2; exit 1; }
   fi
 
   # Verify if SSH key is already added
   if ! ssh-add -l | grep -q "$(basename "$ssh_key")"; then
     if [ -f "$ssh_key" ]; then
-      ssh-add "$ssh_key" > /dev/null 2>&1
+      ssh-add "$ssh_key" > /dev/null 2>&1 || echo "Erreur : Impossible d'ajouter la clé SSH $ssh_key" >&2
+    else
+      echo "Erreur : Clé SSH $ssh_key introuvable" >&2
     fi
   fi
   trap 'ssh-agent -k > /dev/null' EXIT
@@ -51,11 +55,18 @@ do_need_mount() {
     load_ssh_agent
 
     # Check if a repository is already initialized, else init
-    if $RESTIC_COMMAND cat config >> "$LOGFILE" 2>> "$ERRFILE"; then
-      echo "Repository already initialized" >> "$LOGFILE"
+    echo "Vérification de l'initialisation du dépôt Restic..."
+    ynh_print_info "Vérification de l'initialisation du dépôt Restic..."
+
+    if $RESTIC_COMMAND cat config > /dev/null 2>&1; then
+      echo "Dépôt déjà initialisé" >&2
     else
-      echo "Repository not initialized, initializing now" >> "$LOGFILE"
-      $RESTIC_COMMAND init >> "$LOGFILE" 2>> "$ERRFILE"
+      echo "Dépôt non initialisé, initialisation en cours..."
+      if ! $RESTIC_COMMAND init >&2; then
+        echo "Erreur : Échec de l'initialisation du dépôt Restic" >&2
+        exit 1
+      fi
+      echo "Dépôt initialisé avec succès" >&2
     fi
 }
 
@@ -72,18 +83,21 @@ do_backup() {
     load_env_file
     load_ssh_agent
     pushd "$work_dir" > /dev/null
-    $RESTIC_COMMAND backup ./ >> "$LOGFILE" 2>> "$ERRFILE"
-    local backup_return_code=$?
-    popd > /dev/null
-    if [ "$backup_return_code" -eq 0 ]; then
-        echo "Backup successful, running forget policy" >> "$LOGFILE"
-        local forget_policy="$(yunohost app setting __APP__ forget_policy)"
-        $RESTIC_COMMAND forget $forget_policy >> "$LOGFILE" 2>> "$ERRFILE"
-        echo "Forget policy applied: $forget_policy" >> "$LOGFILE"
-    else
-        echo "Backup failed with exit code $backup_return_code" >> "$ERRFILE"
-        exit 1
+
+    echo "Lancement de la sauvegarde..."
+    if ! $RESTIC_COMMAND backup ./ >&2; then
+      echo "Erreur : Échec de la sauvegarde Restic" >&2
+      exit 1
     fi
+
+    echo "Sauvegarde réussie, application de la politique de rétention..."
+    local forget_policy="$(yunohost app setting __APP__ forget_policy)"
+    if ! $RESTIC_COMMAND forget $forget_policy >&2; then
+      echo "Erreur : Échec de l'application de la politique de rétention" >&2
+      exit 1
+    fi
+    echo "Politique de rétention appliquée : $forget_policy" >&2
+    popd > /dev/null
 }
 
 work_dir=$2
@@ -102,7 +116,7 @@ case "$1" in
     do_need_mount "$work_dir" "$name" "$size" "$description"
     ;;
   *)
-    echo "hook called with unknown argument \`$1'" >&2
+    echo "Erreur : Argument inconnu \`$1'" >&2
     exit 1
     ;;
 esac

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -77,8 +77,9 @@ do_backup() {
     popd > /dev/null
     if [ "$backup_return_code" -eq 0 ]; then
         echo "Backup successful, running forget policy" >> "$LOGFILE"
-        $RESTIC_COMMAND forget --keep-daily 7 --keep-weekly 8 --keep-monthly 12 >> "$LOGFILE" 2>> "$ERRFILE"
-        echo "Forget policy applied" >> "$LOGFILE"
+        local forget_policy="$(yunohost app setting __APP__ forget_policy)"
+        $RESTIC_COMMAND forget $forget_policy >> "$LOGFILE" 2>> "$ERRFILE"
+        echo "Forget policy applied: $forget_policy" >> "$LOGFILE"
     else
         echo "Backup failed with exit code $backup_return_code" >> "$ERRFILE"
         exit 1

--- a/conf/backup_method
+++ b/conf/backup_method
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source /usr/share/yunohost/helpers
+source /var/www/__APP__/helpers
 
 set -euo pipefail
 
@@ -13,36 +14,6 @@ RESTIC_PASSWORD=$password
 HOME="/root"
 
 RESTIC_COMMAND=__INSTALL_DIR__/restic
-
-load_env_file() {
-  local env_file="__INSTALL_DIR__/.env"
-  if [ -f "$env_file" ]; then
-    set -o allexport
-    source "$env_file" || { ynh_print_warn "Failed to load environment variables file ($env_file)" >&2; exit 1; }
-    set +o allexport
-  fi
-}
-
-load_ssh_agent() {
-  local ssh_key="/root/.ssh/id___APP___ed25519"
-
-  # Verify if ssh-agent is running, start it otherwise
-  if [ -z "${SSH_AGENT_PID:-}" ] || ! ps -p "$SSH_AGENT_PID" > /dev/null 2>&1; then
-    eval "$(ssh-agent -s)"
-  fi
-
-  # Verify if SSH key is already added
-  if ! ssh-add -l | grep -q "$(basename "$ssh_key")"; then
-    if [ -f "$ssh_key" ]; then
-      if ! ssh-add -q "$ssh_key" >&2; then
-        ynh_print_warn "Failed to add SSH key to agent ($ssh_key)" >&2
-      fi
-    else
-      ynh_print_warn "Failed to find SSH key ($ssh_key)" >&2
-    fi
-  fi
-  trap 'ssh-agent -k > /dev/null' EXIT
-}
 
 do_need_mount() {
     local work_dir="$1"

--- a/conf/check-with-restic
+++ b/conf/check-with-restic
@@ -3,11 +3,10 @@
 errors=""
 current_date=$(date +"%y%m%d_%H%M")
 log_file="/var/log/__APP__/${current_date}.log"
-err_file="/var/log/__APP__/${current_date}.err"
 mkdir -p "/var/log/__APP__"
 
 filter_hooks() {
-    ls /usr/share/yunohost/hooks/backup/ | grep "\-$1_" | cut -d"-" -f2 | uniq 2>> "$err_file"
+    ls /usr/share/yunohost/hooks/backup/ | grep "\-$1_" | cut -d"-" -f2 | uniq 2>&1
 }
 
 CHECK_READ_DATA=${1:-0}
@@ -16,7 +15,7 @@ CHECK_READ_DATA=${1:-0}
 # Check system part conf
 conf=$(sudo yunohost app setting __APP__ conf)
 if [[ "$conf" = "1" ]]; then
-    if ! sudo __INSTALL_DIR__/check_method auto_conf ${CHECK_READ_DATA} 2>> "$err_file" >> "$log_file" ; then
+    if ! sudo __INSTALL_DIR__/check_method auto_conf ${CHECK_READ_DATA} >> "$log_file" 2>&1 ; then
         errors+="\nRestic miserably failed to check backups for system configurations."
     fi
 fi
@@ -24,7 +23,7 @@ fi
 # Check system data
 data=$(sudo yunohost app setting __APP__ data)
 if [[ "$data" = "1" ]]; then
-    if ! sudo __INSTALL_DIR__/check_method auto_data ${CHECK_READ_DATA} 2>> "$err_file" >> "$log_file" ; then
+    if ! sudo __INSTALL_DIR__/check_method auto_data ${CHECK_READ_DATA} >> "$log_file" 2>&1 ; then
         errors+="\nRestic miserably failed to check backups for system data."
     fi
 fi
@@ -35,6 +34,7 @@ fi
 apps=$(sudo yunohost app setting __APP__ apps | sed 's/,[[:space:]]*/,/g')
 apps="${apps//,/ }"
 
+# Initialisation
 include_all=false
 exclude_list=()
 explicit_include_list=()
@@ -71,20 +71,22 @@ for application in $(sudo ls /etc/yunohost/apps/); do
         fi
     fi
 
-    if sudo test ! -f "/etc/yunohost/apps/$application/scripts/backup" ; then
+    # Verify backup script
+    if sudo test ! -f "/etc/yunohost/apps/$application/scripts/backup"; then
         continue
     fi
 
-    if ! sudo __INSTALL_DIR__/check_method auto_${application} ${CHECK_READ_DATA} 2>> "$err_file" >> "$log_file" ; then
+    # Check backup
+    if ! sudo __INSTALL_DIR__/check_method auto_${application} ${CHECK_READ_DATA} >> "$log_file" 2>&1 ; then
         errors+="\nRestic miserably failed to check backups for $application application."
     fi
 done
 
 #=============================================
-# SEND MAIL TO NOTIFY ABOUT  FAILED OPERATIONS
+# SEND MAIL TO NOTIFY ABOUT FAILED OPERATIONS
 #=============================================
 
-partial_errors="$(cat "$log_file" | grep -E "Error|Skipped")"
+partial_errors="$(grep -iE "Error|Skipped|Warning|Fatal|Fail" "$log_file")"
 if [ -n "$partial_errors" ]; then
     errors+="\nSome backup checks partially failed:\n$partial_errors"
 fi
@@ -94,7 +96,7 @@ domain=$(hostname)
 repository="$(sudo yunohost app setting __APP__ repository)"
 if [[ -n "$errors" ]]; then
     sudo yunohost app setting __APP__ state -v "failed"
-    cat <(echo -e "$errors\n\n\n") "$log_file" "$err_file" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[__APP__] Backup checks failed from $domain onto $repository" root
+    echo -e "$errors\n\n\n$(cat "$log_file")" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[__APP__] Backup checks failed from $domain onto $repository" root
 else
     sudo yunohost app setting __APP__ state -v "successful"
 fi

--- a/conf/check-with-restic
+++ b/conf/check-with-restic
@@ -35,12 +35,40 @@ fi
 apps=$(sudo yunohost app setting __APP__ apps | sed 's/,[[:space:]]*/,/g')
 apps="${apps//,/ }"
 
-for application in $(sudo ls /etc/yunohost/apps/); do
+include_all=false
+exclude_list=()
+explicit_include_list=()
 
-    if ( [[ "$apps" =~ ^exclude: ]] && grep -wq "$application" <<< "$apps" ) ||
-       ( [[ "$apps" != "all" ]] && [[ ! "$apps" =~ ^exclude: ]]  && ! grep -wq "$application" <<< "$apps" );
-    then
-        continue
+# Parse app list
+for item in $apps; do
+    if [[ "$item" == "all" ]]; then
+        include_all=true
+    elif [[ "$item" =~ ^exclude: ]]; then
+        exclude_list+=("${item#exclude:}")
+    else
+        # If you are not in "all" mode, add to the explicit inclusion list
+        if ! $include_all; then
+            explicit_include_list+=("$item")
+        # If you are in "all" mode and the element is not prefixed with "exclude:", it is an implicit exclusion.
+        else
+            exclude_list+=("$item")
+        fi
+    fi
+done
+
+# Loop on applications
+for application in $(sudo ls /etc/yunohost/apps/); do
+    # Exclude/Include logic
+    if $include_all; then
+        # "All" mode: those in exclude_list are excluded.
+        if printf '%s\n' "${exclude_list[@]}" | grep -q "^${application}\$"; then
+            continue
+        fi
+    else
+        # Explicit inclusion mode: only those in explicit_include_list are included.
+        if ! printf '%s\n' "${explicit_include_list[@]}" | grep -q "^${application}\$"; then
+            continue
+        fi
     fi
 
     if sudo test ! -f "/etc/yunohost/apps/$application/scripts/backup" ; then

--- a/conf/check_method
+++ b/conf/check_method
@@ -3,7 +3,8 @@
 set -e
 
 RESTIC_REPOSITORY_BASE=$(yunohost app setting __APP__ repository)
-RESTIC_PASSWORD="$(yunohost app setting __APP__ passphrase)"
+password=$(ynh_app_setting_get --app=__APP__ --key=passphrase)
+RESTIC_PASSWORD=$password
 RESTIC_COMMAND=__INSTALL_DIR__/restic
 
 load_env_file() {

--- a/conf/check_method
+++ b/conf/check_method
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source /usr/share/yunohost/helpers
+source /var/www/__APP__/helpers
 
 set -e
 
@@ -9,30 +10,6 @@ password=$(ynh_app_setting_get --app=__APP__ --key=passphrase)
 RESTIC_PASSWORD=$password
 RESTIC_COMMAND=__INSTALL_DIR__/restic
 
-load_env_file() {
-  local env_file="__INSTALL_DIR__/.env"
-  if [ -f "$env_file" ]; then
-    set -o allexport
-    source "$env_file"
-    set +o allexport
-  fi
-}
-
-load_ssh_agent() {
-  local ssh_key="/root/.ssh/id___APP___ed25519"
-
-  if [ -z "${SSH_AGENT_PID:-}" ] || ! ps -p "$SSH_AGENT_PID" > /dev/null 2>&1; then
-    eval "$(ssh-agent -s)"
-  fi
-
-  if ! ssh-add -l | grep -q "$(basename "$ssh_key")"; then
-    if [ -f "$ssh_key" ]; then
-      ssh-add "$ssh_key" > /dev/null 2>&1
-    fi
-  fi
-  trap 'ssh-agent -k > /dev/null' EXIT
-}
-
 do_check() {
     local name="$1"
     local check_read_data="$2"
@@ -40,38 +17,16 @@ do_check() {
     export RESTIC_PASSWORD
     export RESTIC_REPOSITORY=${RESTIC_REPOSITORY_BASE}/$name
 
-    LOGFILE=/var/log/__APP__/check.log
-    ERRFILE=/var/log/__APP__/check-error.log
-    local current_date
-    current_date=$(date --iso-8601=seconds)
-
     load_env_file
     load_ssh_agent
 
-    {
-      echo -e "\n$current_date"
-      echo -e "BEGIN REPO CHECK: ${name}"
-    } >> "$LOGFILE"
-    {
-      echo -e "\n$current_date"
-      echo -e "BEGIN REPO CHECK: ${name}"
-    } >> "$ERRFILE"
-
     if [ "$check_read_data" -eq 1 ]; then
-      $RESTIC_COMMAND check --read-data >> "$LOGFILE" 2>> "$ERRFILE"
+        $RESTIC_COMMAND check --read-data -q
     else
-      $RESTIC_COMMAND check >> "$LOGFILE" 2>> "$ERRFILE"
+        $RESTIC_COMMAND check -q
     fi
-    local check_return_code=$?
 
-    {
-      echo -e "END REPO CHECK: ${name}"
-    } >> "$LOGFILE"
-    {
-      echo -e "END REPO CHECK: ${name}"
-    } >> "$ERRFILE"
-
-    return "$check_return_code"
+    return $?
 }
 
 name=$1

--- a/conf/check_method
+++ b/conf/check_method
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /usr/share/yunohost/helpers
+
 set -e
 
 RESTIC_REPOSITORY_BASE=$(yunohost app setting __APP__ repository)

--- a/conf/helpers
+++ b/conf/helpers
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-source /usr/share/yunohost/helpers
-
 load_env_file() {
   local env_file="__INSTALL_DIR__/.env"
   if [ -f "$env_file" ]; then
     set -o allexport
-    source "$env_file" || { ynh_print_warn "Failed to load environment variables file ($env_file)" >&2; exit 1; }
+    source "$env_file" || { echo "Failed to load environment variables file ($env_file)" >&2; exit 1; }
     set +o allexport
   fi
 }
@@ -23,10 +21,10 @@ load_ssh_agent() {
   if ! ssh-add -l | grep -q "$(basename "$ssh_key")"; then
     if [ -f "$ssh_key" ]; then
       if ! ssh-add -q "$ssh_key" >&2; then
-        ynh_print_warn "Failed to add SSH key to agent ($ssh_key)" >&2
+        echo "Failed to add SSH key to agent ($ssh_key)" >&2
       fi
     else
-      ynh_print_warn "Failed to find SSH key ($ssh_key)" >&2
+      echo "Failed to find SSH key ($ssh_key)" >&2
     fi
   fi
   trap 'ssh-agent -k > /dev/null' EXIT

--- a/conf/helpers
+++ b/conf/helpers
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+source /usr/share/yunohost/helpers
+
+load_env_file() {
+  local env_file="__INSTALL_DIR__/.env"
+  if [ -f "$env_file" ]; then
+    set -o allexport
+    source "$env_file" || { ynh_print_warn "Failed to load environment variables file ($env_file)" >&2; exit 1; }
+    set +o allexport
+  fi
+}
+
+load_ssh_agent() {
+  local ssh_key="/root/.ssh/id___APP___ed25519"
+
+  # Verify if ssh-agent is running, start it otherwise
+  if [ -z "${SSH_AGENT_PID:-}" ] || ! ps -p "$SSH_AGENT_PID" > /dev/null 2>&1; then
+    eval "$(ssh-agent -s)"
+  fi
+
+  # Verify if SSH key is already added
+  if ! ssh-add -l | grep -q "$(basename "$ssh_key")"; then
+    if [ -f "$ssh_key" ]; then
+      if ! ssh-add -q "$ssh_key" >&2; then
+        ynh_print_warn "Failed to add SSH key to agent ($ssh_key)" >&2
+      fi
+    else
+      ynh_print_warn "Failed to find SSH key ($ssh_key)" >&2
+    fi
+  fi
+  trap 'ssh-agent -k > /dev/null' EXIT
+}

--- a/conf/sudoer
+++ b/conf/sudoer
@@ -1,1 +1,2 @@
 __APP__ ALL=(root) NOPASSWD: /usr/bin/yunohost app setting *, /usr/bin/yunohost backup create *, /bin/journalctl*, __INSTALL_DIR__/*, /bin/ls, /usr/bin/test
+Defaults:__APP__ env_keep += "BACKUP_CORE_ONLY"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -2,7 +2,8 @@ version = "1.0"
 
 [main]
 services = []
-name="Restic settings"
+name.en = "Restic settings"
+name.fr = "Paramètres de Restic"
 
     [main.state]
     name = ""
@@ -16,9 +17,13 @@ name="Restic settings"
 
     [main.general]
         [main.general.info]
-        ask = """\
+        ask.en = """\
         Backup state : {{state}}
         Last run: {{last_run}}
+        """
+        ask.fr = """\
+        Statut de la sauvegarde : {{state}}
+        Dernière exécution : {{last_run}}
         """
         type = "alert"
         style = "info"
@@ -32,6 +37,7 @@ name="Restic settings"
 
         [main.general.ssh_public_key]
         ask.en = "Public key: {ssh_public_key}"
+        ask.fr = "Clé publique : {ssh_public_key}"
         type = "markdown"
         bind = "/root/.ssh/id___APP___ed25519.pub"
 
@@ -39,29 +45,30 @@ name="Restic settings"
         ask.en = "When and at which frequency should the backups be performed?"
         ask.fr = "Quand et à quelle fréquence les sauvegardes doivent-elles être effectuées ?"
         type = "string"
-        help = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
+        help.en = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
+        help.fr = "Par exemple : `Monthly`, `Weekly`, `Daily` (= tous les jours à minuit), `Hourly`, `Sat *-*-1..7 18:00:00` (= le premier samedi de chaque mois à 18h00), `4:00` (= tous les jours à 4h du matin), `5,17:00` (= tous les jours à 5h et 17h). Pour la syntaxe complète, consultez la [documentation du format OnCalendar de systemd](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)."
         default = "Daily"
         bind = "OnCalendar:/etc/systemd/system/__APP__.timer"
 
-        [main.general.check_connection]
-        type = "button"
-        ask.en = "Test connection"
-        ask.fr = "Tester la connexion"
-        
     [main.content]
-    name = "What should be backed up?"
+    name.en = "What should be backed up?"
+    name.fr = "Que faut-il sauvegarder ?"
     optional = false
 
         [main.content.conf]
-        ask.en = "Configuration"
+        ask.en = "Server configuration"
+        ask.fr = "Configuration du serveur"
         type = "boolean"
 
         [main.content.data]
-        ask.en = "Data"
+        ask.en = "Server and user data (home directory and emails)"
+        ask.fr = "Données du serveur et des utilisateurs (dossier home et e-mails)"
         type = "boolean"
+        enabled = "!backup_core_only"
 
         [main.content.data_multimedia]
         ask.en = "Multimedia"
+        ask.fr = "Multimédia"
         type = "boolean"
 
         [main.content.apps]
@@ -76,7 +83,8 @@ name="Restic settings"
         type = "boolean"
 
     [main.advanced]
-    name = "Advanced configuration"
+    name.en = "Advanced configuration"
+    name.fr = "Configuration avancée"
     optional = true
 
         [main.advanced.environment]
@@ -93,14 +101,16 @@ name="Restic settings"
         ask.en = "When and at which frequency should the backup checks be performed?"
         ask.fr = "Quand et à quelle fréquence les tests de sauvegarde doivent-ils être effectués ?"
         type = "string"
-        help = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
+        help.en = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
+        help.fr = "Par exemple : `Monthly`, `Weekly`, `Daily` (= tous les jours à minuit), `Hourly`, `Sat *-*-1..7 18:00:00` (= le premier samedi de chaque mois à 18h00), `4:00` (= tous les jours à 4h du matin), `5,17:00` (= tous les jours à 5h et 17h). Pour la syntaxe complète, consultez la [documentation du format OnCalendar de systemd](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)."
         bind = "OnCalendar:/etc/systemd/system/__APP___check.timer"
 
         [main.advanced.check_read_data_on_calendar]
         ask.en = "When and at which frequency should the full backup checks be performed?"
         ask.fr = "Quand et à quelle fréquence les tests complets de sauvegarde doivent-ils être effectués ?"
         type = "string"
-        help = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
+        help.en = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
+        help.fr = "Par exemple : `Monthly`, `Weekly`, `Daily` (= tous les jours à minuit), `Hourly`, `Sat *-*-1..7 18:00:00` (= le premier samedi de chaque mois à 18h00), `4:00` (= tous les jours à 4h du matin), `5,17:00` (= tous les jours à 5h et 17h). Pour la syntaxe complète, consultez la [documentation du format OnCalendar de systemd](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)."
         bind = "OnCalendar:/etc/systemd/system/__APP___check_read_data.timer"
 
         [main.advanced.forget_policy]
@@ -110,3 +120,18 @@ name="Restic settings"
         help.en = "Restic forget options to clean up old backups. For example: --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"
         help.fr = "Options Restic forget pour nettoyer les anciennes sauvegardes. Par exemple : --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"
         default = "--keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"
+
+    [main.actions]
+    name = "Actions"
+    optional = true
+
+        [main.actions.check_connection]
+        type = "button"
+        ask.en = "Test connection"
+        ask.fr = "Tester la connexion"
+        
+        [main.actions.now]
+        type = "button"
+        ask.en = "Run backup now"
+        ask.fr = "Faire une sauvegarde immédiatement"
+        

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -41,7 +41,8 @@ name="Restic settings"
         type = "string"
         help = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
         default = "Daily"
-        
+        bind = "OnCalendar:/etc/systemd/system/__APP__.timer"
+
         [main.general.check_connection]
         type = "button"
         ask.en = "Test connection"
@@ -71,7 +72,7 @@ name="Restic settings"
         
         [main.content.backup_core_only]
         ask.en = "Backup only the core (won't backup any data of any app)"
-        ask.fr = "Sauvegarder uniquement la configuration (aucune donnée d'aucune application ne sera sauvegardée)
+        ask.fr = "Sauvegarder uniquement la configuration (aucune donnée d'aucune application ne sera sauvegardée)"
         type = "boolean"
 
     [main.advanced]
@@ -93,12 +94,14 @@ name="Restic settings"
         ask.fr = "Quand et à quelle fréquence les tests de sauvegarde doivent-ils être effectués ?"
         type = "string"
         help = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
+        bind = "OnCalendar:/etc/systemd/system/__APP___check.timer"
 
         [main.advanced.check_read_data_on_calendar]
         ask.en = "When and at which frequency should the full backup checks be performed?"
         ask.fr = "Quand et à quelle fréquence les tests complets de sauvegarde doivent-ils être effectués ?"
         type = "string"
         help = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
+        bind = "OnCalendar:/etc/systemd/system/__APP___check_read_data.timer"
 
         [main.advanced.forget_policy]
         ask.en = "Forget policy for old backups"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -90,3 +90,11 @@ name="Restic settings"
         ask.fr = "Quand et à quelle fréquence les tests complets de sauvegarde doivent-ils être effectués ?"
         type = "string"
         help = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
+
+        [main.advanced.forget_policy]
+        ask.en = "Forget policy for old backups"
+        ask.fr = "Politique d'oubli pour les anciennes sauvegardes"
+        type = "string"
+        help.en = "Restic forget options to clean up old backups. For example: --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"
+        help.fr = "Options Restic forget pour nettoyer les anciennes sauvegardes. Par exemple : --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"
+        default = "--keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -69,6 +69,11 @@ name="Restic settings"
         help.en = "App list separated by spaces. You can write 'all' to select all apps, including those installed after this Restic app. You can also select all apps except some by writing 'exclude:' followed by a space-separated list of apps."
         help.fr = "Liste d'applications séparées par des espaces. Vous pouvez écrire 'all' pour sélectionner toutes les apps, y compris celles installées après cette application Restic. Vous pouvez aussi sélectionner toutes les apps sauf certaines en écrivant 'exclude:' suivi d'une liste d'applications séparées par des espaces."        
         
+        [main.content.backup_core_only]
+        ask.en = "Backup only the core (won't backup any data of any app)"
+        ask.fr = "Sauvegarder uniquement la configuration (aucune donnée d'aucune application ne sera sauvegardée)
+        type = "boolean"
+
     [main.advanced]
     name = "Advanced configuration"
     optional = true

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -42,6 +42,10 @@ name="Restic settings"
         help = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
         default = "Daily"
         
+        [main.general.check_connection]
+        type = "button"
+        ask.en = "Test connection"
+        ask.fr = "Tester la connexion"
         
     [main.content]
     name = "What should be backed up?"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -17,13 +17,9 @@ name.fr = "Paramètres de Restic"
 
     [main.general]
         [main.general.info]
-        ask.en = """\
+        ask = """\
         Backup state : {{state}}
         Last run: {{last_run}}
-        """
-        ask.fr = """\
-        Statut de la sauvegarde : {{state}}
-        Dernière exécution : {{last_run}}
         """
         type = "alert"
         style = "info"
@@ -64,7 +60,6 @@ name.fr = "Paramètres de Restic"
         ask.en = "Server and user data (home directory and emails)"
         ask.fr = "Données du serveur et des utilisateurs (dossier home et e-mails)"
         type = "boolean"
-        enabled = "!backup_core_only"
 
         [main.content.data_multimedia]
         ask.en = "Multimedia"

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -74,3 +74,20 @@ mv roundcube_restore.tar /home/yunohost.backup/archives/
 ```
 
 Once the archive is in place, YunoHost will recognize it, and you can proceed with the restoration using the YunoHost admin interface or CLI tools.
+
+### Common Errors
+
+- **SFTP Server as Remote Repository:**
+  When specifying the address for an SFTP remote repository, ensure you use the correct format:
+  `sftp://backup_user@target_server.tld:ssh_port//your/folder/`
+  *(Note the double slash after the port number.)*
+
+- **Host Key Verification Failed (SFTP):**
+  If you encounter the error `subprocess ssh: Host key verification failed.` when connecting to a remote repository via SFTP, it is often due to incorrect permissions on the SSH key. To fix this, run:
+  `chmod 600 /root/.ssh/id___APP___ed25519`
+
+- **Chroot Environment (SFTP):**
+  If the remote system uses a "chroot" environment (e.g., another YunoHost server with the SSH configuration `ChrootDirectory %h`), the home directory path is not `/home/user` but rather `/user`.
+
+- **Backblaze B2 as Remote Repository:**
+  When using Backblaze B2, if you do not specify a subfolder, you must still append a `:` to the end of the address. This allows Restic to append the subfolder to the address (e.g., changing `b2:xxxxxxxxxxx:` to `b2:xxxxxxxxxxx:/auto_<app>`). This resolves the error "bucket name contains invalid characters."

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,27 +1,12 @@
-### Test
-
-You can manually trigger backups using: `systemctl start __APP__.service`
-
-And then make sure to verify the backup contents using: `restic -r __REPOSITORY__/auto_conf snapshots`
-
-(Replace `auto_conf` with `auto_<app>` if you did not choose to backup configuration but only applications)
-
-### Misc helpful commands
+### Command-line usage
 
 - Display the apps list to backup: `yunohost app setting restic apps`
 - Edit the apps list to backup: `yunohost app setting restic apps -v "nextcloud,wordpress"`
-- Launch a backup manually: `systemctl start restic`
-- Launch a backup consistency check: `systemctl start restic_check.service`
+- Trigger a backup manually: `systemctl start restic`
+- Trigger a backup consistency check: `systemctl start restic_check`
+- Trigger a complete check of the backups (this reads all the backed up data, it can take some time): `systemctl start restic_check_read_data`
 
-#### Launch a complete backup check
-
-If you want to make a complete check of the backups - keep in mind that this reads all the backed up data, it can take some time depending on your target server upload speed (more on this topic in [the Restic documentation](https://restic.readthedocs.io/en/latest/045_working_with_repos.html#checking-integrity-and-consistency)):
-
-```
-systemctl start restic_check_read_data.service
-```
-
-#### How to verify if backups succeeded
+### How to verify if backups succeeded
 
 To verify if your automatic Restic backups succeeded, follow these steps:
 
@@ -41,7 +26,7 @@ s3:https://server:port/bucket_name
 
 For each YunoHost application, Restic stores backups in a subdirectory of the repository. For example, Roundcube backups are stored in `/auto_roundcube`, and Nextcloud backups are stored in `/auto_nextcloud`.
 
-If you’re using SFTP, the SSH key is tied to the root user, so you must be logged in as root. For all other repository types (S3, B2, etc.), navigate to the Restic directory:
+If you're using SFTP, the SSH key is tied to the root user, so you must be logged in as root. For all other repository types (S3, B2, etc.), navigate to the Restic directory:
 ```bash
 cd /var/www/restic/
 ```
@@ -58,11 +43,11 @@ To verify the latest backup, list its contents with:
 ```bash
 ./restic -r "$RESTIC_REPOSITORY" ls latest
 ```
-If the backup succeeded, you’ll see a list of files and directories. 
+If the backup succeeded, you'll see a list of files and directories. 
 
-#### How to restore from Restic backups
+### How to restore from Restic backups
 
-To restore a backup using Restic, start by accessing the repository as described in the previous guide. Ensure you’re logged in as **root** and, if not using SFTP, load the environment variables:
+To restore a backup using Restic, start by accessing the repository as described in the previous guide. Ensure you're logged in as **root** and, if not using SFTP, load the environment variables:
 ```bash
 source /var/www/restic/.env
 ```

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -13,11 +13,79 @@ And then make sure to verify the backup contents using: `restic -r __REPOSITORY_
 - Launch a backup manually: `systemctl start restic`
 - Launch a backup consistency check: `systemctl start restic_check.service`
 
-##### Launch a complete backup check
-
+#### Launch a complete backup check
 
 If you want to make a complete check of the backups - keep in mind that this reads all the backed up data, it can take some time depending on your target server upload speed (more on this topic in [the Restic documentation](https://restic.readthedocs.io/en/latest/045_working_with_repos.html#checking-integrity-and-consistency)):
 
 ```
 systemctl start restic_check_read_data.service
 ```
+
+#### How to verify if backups succeeded
+
+To verify if your automatic Restic backups succeeded, follow these steps:
+
+First, you need root access to the server. If your repository is not using SFTP, load the Restic environment variables by running:
+```bash
+source /var/www/restic/.env
+```
+
+To get the target repository URL used by Restic, run:
+```bash
+yunohost app setting restic repository
+```
+This will return something like:
+```
+s3:https://server:port/bucket_name
+```
+
+For each YunoHost application, Restic stores backups in a subdirectory of the repository. For example, Roundcube backups are stored in `/auto_roundcube`, and Nextcloud backups are stored in `/auto_nextcloud`.
+
+If you’re using SFTP, the SSH key is tied to the root user, so you must be logged in as root. For all other repository types (S3, B2, etc.), navigate to the Restic directory:
+```bash
+cd /var/www/restic/
+```
+Then load the environment variables:
+```bash
+source .env
+```
+Set the `RESTIC_REPOSITORY` variable to include the subdirectory for the app you want to check. For example, for Roundcube:
+```bash
+RESTIC_REPOSITORY=$(yunohost app setting restic repository)/auto_roundcube
+```
+
+To verify the latest backup, list its contents with:
+```bash
+./restic -r "$RESTIC_REPOSITORY" ls latest
+```
+If the backup succeeded, you’ll see a list of files and directories. 
+
+#### How to restore from Restic backups
+
+To restore a backup using Restic, start by accessing the repository as described in the previous guide. Ensure you’re logged in as **root** and, if not using SFTP, load the environment variables:
+```bash
+source /var/www/restic/.env
+```
+
+Navigate to the Restic directory:
+```bash
+cd /var/www/restic/
+```
+
+Set the `RESTIC_REPOSITORY` variable to point to the subdirectory of the app you want to restore. For example, for Roundcube:
+```bash
+RESTIC_REPOSITORY=$(yunohost app setting restic repository)/auto_roundcube
+```
+
+Next, create a `.tar` archive of the files you want to restore. For example, to restore the latest snapshot:
+```bash
+./restic -r "$RESTIC_REPOSITORY" dump latest > roundcube_restore.tar
+```
+This command extracts the latest backup into a `.tar` file named `roundcube_restore.tar`.
+
+Move the `.tar` archive to `/home/yunohost.backup/archives/` so YunoHost can detect it:
+```bash
+mv roundcube_restore.tar /home/yunohost.backup/archives/
+```
+
+Once the archive is in place, YunoHost will recognize it, and you can proceed with the restoration using the YunoHost admin interface or CLI tools.

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -82,3 +82,20 @@ source /var/www/restic/.env
    ```
 
 5. **Restauration** : Une fois l'archive en place, YunoHost la reconnaîtra, et vous pourrez procéder à la restauration via l'interface d'administration ou les outils en ligne de commande de YunoHost.
+
+### Erreurs fréquentes
+
+- **Utilisation d’un serveur SFTP comme dépôt distant :**
+  Pour spécifier l’adresse d’un dépôt distant SFTP, utilisez ce format exact :
+  `sftp://utilisateur_backup@serveur_cible.tld:port_ssh//votre/dossier/`
+  *(Attention aux doubles barres obliques après le port.)*
+
+- **Échec de vérification de la clé hôte (SFTP) :**
+  Si l’erreur `subprocess ssh: Host key verification failed.` apparaît lors de la connexion à un dépôt SFTP, cela est souvent dû à des permissions incorrectes sur la clé SSH. Pour corriger le problème, exécutez :
+  `chmod 600 /root/.ssh/id___APP___ed25519`
+
+- **Environnement "chroot" (SFTP) :**
+  Si le système distant utilise un environnement "chroot" (par exemple, un autre serveur YunoHost avec la configuration SSH `ChrootDirectory %h`), le chemin du dossier racine n’est pas `/home/utilisateur`, mais simplement `/utilisateur`.
+
+- **Utilisation de Backblaze B2 comme dépôt distant :**
+  Avec Backblaze B2, si vous ne précisez pas de sous-dossier, ajoutez tout de même un `:` à la fin de l’adresse. Cela permet à Restic d’ajouter automatiquement le sous-dossier (par exemple, transformer `b2:xxxxxxxxxxx:` en `b2:xxxxxxxxxxx:/auto_<app>`). Cette étape évite l’erreur *"bucket name contains invalid characters"*.

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -1,0 +1,84 @@
+### Utilisation en ligne de commande
+
+- Afficher la liste des applications à sauvegarder :
+  `yunohost app setting restic apps`
+- Modifier la liste des applications à sauvegarder :
+  `yunohost app setting restic apps -v "nextcloud,wordpress"`
+- Lancer une sauvegarde manuellement :
+  `systemctl start restic`
+- Lancer une vérification de la cohérence des sauvegardes :
+  `systemctl start restic_check`
+- Lancer une vérification complète des sauvegardes (cela lit toutes les données sauvegardées, ce qui peut prendre du temps) :
+  `systemctl start restic_check_read_data`
+
+### Comment vérifier si les sauvegardes ont réussi
+
+Pour vérifier si vos sauvegardes automatiques Restic ont réussi, suivez ces étapes :
+
+1. **Accès root** : Vous devez avoir un accès root au serveur. Si votre dépôt n'utilise pas SFTP, chargez les variables d'environnement de Restic en exécutant :
+   ```bash
+   source /var/www/restic/.env
+   ```
+
+2. **Récupérer l'URL du dépôt** : Pour obtenir l'URL du dépôt utilisé par Restic, exécutez :
+   ```bash
+   yunohost app setting restic repository
+   ```
+   Cela retournera quelque chose comme :
+   ```
+   s3:https://serveur:port/nom_du_bucket
+   ```
+
+3. **Structure des sauvegardes** : Pour chaque application YunoHost, Restic stocke les sauvegardes dans un sous-dossier du dépôt. Par exemple, les sauvegardes de Roundcube sont stockées dans `/auto_roundcube`, et celles de Nextcloud dans `/auto_nextcloud`.
+
+4. **Accès au dépôt** :
+   - Si vous utilisez **SFTP**, la clé SSH est liée à l'utilisateur root, vous devez donc être connecté en tant que root.
+   - Pour tous les autres types de dépôts (S3, B2, etc.), accédez au répertoire Restic :
+     ```bash
+     cd /var/www/restic/
+     ```
+     Puis chargez les variables d'environnement :
+     ```bash
+     source .env
+     ```
+
+5. **Vérification d'une sauvegarde spécifique** : Définissez la variable `RESTIC_REPOSITORY` pour inclure le sous-dossier de l'application que vous souhaitez vérifier. Par exemple, pour Roundcube :
+   ```bash
+   RESTIC_REPOSITORY=$(yunohost app setting restic repository)/auto_roundcube
+   ```
+
+6. **Lister le contenu de la dernière sauvegarde** : Pour vérifier la dernière sauvegarde, listez son contenu avec :
+   ```bash
+   ./restic -r "$RESTIC_REPOSITORY" ls latest
+   ```
+   Si la sauvegarde a réussi, vous verrez une liste de fichiers et de dossiers.
+
+### Comment restaurer depuis les sauvegardes Restic
+
+Pour restaurer une sauvegarde avec Restic, commencez par accéder au dépôt comme décrit précédemment. Assurez-vous d'être connecté en tant que **root** et, si vous n'utilisez pas SFTP, chargez les variables d'environnement :
+```bash
+source /var/www/restic/.env
+```
+
+1. **Accéder au répertoire Restic** :
+   ```bash
+   cd /var/www/restic/
+   ```
+
+2. **Définir le dépôt cible** : Définissez la variable `RESTIC_REPOSITORY` pour pointer vers le sous-dossier de l'application que vous souhaitez restaurer. Par exemple, pour Roundcube :
+   ```bash
+   RESTIC_REPOSITORY=$(yunohost app setting restic repository)/auto_roundcube
+   ```
+
+3. **Créer une archive `.tar`** : Créez une archive `.tar` des fichiers que vous souhaitez restaurer. Par exemple, pour restaurer le dernier snapshot :
+   ```bash
+   ./restic -r "$RESTIC_REPOSITORY" dump latest > roundcube_restore.tar
+   ```
+   Cette commande extrait la dernière sauvegarde dans un fichier `.tar` nommé `roundcube_restore.tar`.
+
+4. **Déplacer l'archive** : Déplacez l'archive `.tar` vers `/home/yunohost.backup/archives/` pour que YunoHost puisse la détecter :
+   ```bash
+   mv roundcube_restore.tar /home/yunohost.backup/archives/
+   ```
+
+5. **Restauration** : Une fois l'archive en place, YunoHost la reconnaîtra, et vous pourrez procéder à la restauration via l'interface d'administration ou les outils en ligne de commande de YunoHost.

--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -7,5 +7,5 @@ A [Restic](https://restic.net/) integration to backup your YunoHost server to an
 - **Flexibility**: Install multiple instances to backup to different locations or set custom frequencies.
 
 ### Configuration
-- **SFTP**: Configure directly during installation.
-- **Other backends**: Set the required environment variables in the **App Panel** after installation.
+- **SFTP**: A SSH key will be generated during installation, you'll have to allow it on your destination server.
+- **Other backends**: Set the required environment variables in the **Config Panel** after installation.

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -1,0 +1,11 @@
+**[Restic](https://restic.net/)** est un outil de sauvegarde sécurisé et efficace pour sauvegarder votre serveur vers un stockage externe.
+
+### Fonctionnalités
+- **Plusieurs types de stockage** : Prise en charge de tous les backends compatibles avec Restic (SFTP, S3, Backblaze B2, Azure, etc.). **SFTP est recommandé** pour sa simplicité.
+- **Déduplication et compression** : Économise de l'espace en supprimant les doublons et en compressant les données.
+- **Chiffrement** : Les données sont chiffrées avant d'être envoyées vers le stockage externe.
+- **Flexibilité** : Possibilité d'installer plusieurs instances pour sauvegarder vers différents emplacements ou définir des fréquences personnalisées.
+
+### Configuration
+- **SFTP** : Une clé SSH sera générée lors de l'installation. Vous devrez l'autoriser sur votre serveur de destination.
+- **Autres backends** : Après l'installation, configurez les variables d'environnement requises dans le **Panneau de configuration**.

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -26,3 +26,11 @@ Match User __SSH_USER__
 EOF
 systemctl restart ssh
 ```
+
+-----
+
+If you're using another backup provider, add your environment variables on the App Config Panel.
+
+-----
+
+After allowing the SSH key or adding your environment variables, you can test that the connection is working with "Test connection" feature on the App Config Panel.

--- a/doc/POST_INSTALL_fr.md
+++ b/doc/POST_INSTALL_fr.md
@@ -1,0 +1,35 @@
+Si vous utilisez **SFTP**, vous devez autoriser la clé publique suivante sur le serveur de destination :
+
+`__PUBLIC_KEY__`
+
+Pour ce faire, exécutez ces commandes sur le serveur cible :
+
+```bash
+mkdir -p ~/.ssh
+touch ~/.ssh/authorized_keys
+chmod u=rw,go= ~/.ssh/authorized_keys
+echo "__PUBLIC_KEY__" >> ~/.ssh/authorized_keys
+```
+
+Assurez-vous également que le chemin existe et est accessible en écriture par votre utilisateur.
+
+**Optionnel** : Pour améliorer la sécurité, limitez l'accès de l'utilisateur à SFTP uniquement et restreignez-le à son répertoire personnel sur le serveur cible. Sur Debian/Ubuntu, cela se fait avec la commande suivante :
+
+```bash
+cat << EOF >> /etc/ssh/sshd_config
+Match User __SSH_USER__
+   ChrootDirectory %h
+   ForceCommand internal-sftp
+   AllowTcpForwarding no
+   X11Forwarding no
+EOF
+systemctl restart ssh
+```
+
+---
+
+Si vous utilisez un autre fournisseur de sauvegarde, ajoutez vos variables d'environnement dans le **Panneau de configuration de l'application**.
+
+---
+
+Une fois la clé SSH autorisée ou les variables d'environnement ajoutées, vous pouvez tester la connexion en utilisant l'action **« Tester la connexion »** dans le Panneau de configuration de l'application.

--- a/doc/POST_UPGRADE.d/0.18.1~ynh2.md
+++ b/doc/POST_UPGRADE.d/0.18.1~ynh2.md
@@ -1,0 +1,16 @@
+This update improves Restic integration inside YunoHost systems.
+
+## What’s New
+
+- The main log now unifies all logs and errors from sub-processes and scripts.
+- You can now define your own retention rules for backups (forget policy).
+- A new button allows you to verify connection to the backup provider before running backups.
+- You can choose to back up only the core system (excluding user data).
+- Added comprehensive documentation in both French and English.
+
+## Bug Fixes
+
+- Passwords are now masked in logs shared via YunoPaste.
+- The `exclude:` rule system has been rewritten for greater flexibility and precision.
+- systemd timers are now fully synchronized with the configuration panel, allowing edits directly from the UI.
+- Upgrades now automatically set correct file permissions for private keys.

--- a/doc/POST_UPGRADE.d/0.18.1~ynh2_fr.md
+++ b/doc/POST_UPGRADE.d/0.18.1~ynh2_fr.md
@@ -1,0 +1,16 @@
+Cette mise à jour améliore l'intégration de Restic au sein des systèmes YunoHost.
+
+## Nouveautés
+
+- Le journal principal regroupe désormais tous les journaux et erreurs provenant des sous-processus et des scripts.
+- Vous pouvez désormais définir vos propres règles de conservation pour les sauvegardes (politique d'oubli).
+- Un nouveau bouton vous permet de vérifier la connexion au fournisseur de sauvegarde avant d'exécuter les sauvegardes.
+- Vous pouvez choisir de ne sauvegarder que le système central (à l'exclusion des données utilisateur).
+- Ajout d'une documentation complète en français et en anglais.
+
+## Corrections de bugs
+
+- Les mots de passe sont désormais masqués dans les journaux partagés via YunoPaste.
+- Le système de règles « exclude: » a été réécrit pour plus de flexibilité et de précision.
+- Les minuteries systemd sont désormais entièrement synchronisées avec le panneau de configuration, ce qui permet de les modifier directement depuis l'interface utilisateur.
+- Les mises à niveau définissent désormais automatiquement les permissions de fichiers correctes pour les clés privées.

--- a/manifest.toml
+++ b/manifest.toml
@@ -70,7 +70,8 @@ ram.runtime = "50M"
     ask.en = "When and at which frequency should the backups be performed?"
     ask.fr = "Quand et à quelle fréquence les sauvegardes doivent-elles être effectuées ?"
     type = "string"
-    help = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
+    help.en = "For example: `Monthly`, `Weekly`, `Daily` (=every day at midnight), `Hourly`, `Sat *-*-1..7 18:00:00` (=the first saturday of every month at 18:00), `4:00` (=every day at 4 AM), `5,17:00` (=every day at 5 AM and 5 PM). See the [systemd OnCalendar format for full syntax doc](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)"
+    help.fr = "Par exemple : `Monthly`, `Weekly`, `Daily` (= tous les jours à minuit), `Hourly`, `Sat *-*-1..7 18:00:00` (= le premier samedi de chaque mois à 18h00), `4:00` (= tous les jours à 4h du matin), `5,17:00` (= tous les jours à 5h et 17h). Pour la syntaxe complète, consultez la [documentation du format OnCalendar de systemd](https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer)."
     default = "Daily"
 
 [resources]

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Restic"
 description.en = "Regularly create encrypted backups sent to another server using Restic"
 description.fr = "Créez régulièrement des sauvegardes chiffrées envoyées sur un autre serveur avec Restic"
 
-version = "0.18.1~ynh1"
+version = "0.18.1~ynh2"
 
 maintainers = ["Gildas-GH"]
 

--- a/scripts/config
+++ b/scripts/config
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source /usr/share/yunohost/helpers
+source /var/www/$app/helpers
 
 ynh_abort_if_errors
 
@@ -80,40 +81,12 @@ set__data_multimedia() {
 # SPECIFIC ACTIONS FOR TOML SHORT KEY
 #=================================================
 
-__load_env_file() {
-  local env_file="$app/.env"
-  if [ -f "$env_file" ]; then
-    set -o allexport
-    source "$env_file" || { ynh_print_warn "Erreur : Impossible de charger le fichier d'environnement $env_file" >&2; exit 1; }
-    set +o allexport
-  fi
-}
-
-__load_ssh_agent() {
-  local ssh_key="/root/.ssh/id_${app}_ed25519"
-
-  # Verify if ssh-agent is running, start it otherwise
-  if [ -z "${SSH_AGENT_PID:-}" ] || ! ps -p "$SSH_AGENT_PID" > /dev/null 2>&1; then
-    eval "$(ssh-agent -s)" || { ynh_print_warn "Erreur : Impossible de démarrer ssh-agent" >&2; exit 1; }
-  fi
-
-  # Verify if SSH key is already added
-  if ! ssh-add -l | grep -q "$(basename "$ssh_key")"; then
-    if [ -f "$ssh_key" ]; then
-      ssh-add "$ssh_key" > /dev/null 2>&1 || ynh_print_warn "Erreur : Impossible d'ajouter la clé SSH $ssh_key" >&2
-    else
-      ynh_print_warn "Erreur : Clé SSH $ssh_key introuvable" >&2
-    fi
-  fi
-  trap 'ssh-agent -k > /dev/null' EXIT
-}
-
 run__check_connection() {
     local output
     local exit_code
     pushd "/var/www/$app"
-    __load_env_file
-    __load_ssh_agent
+    load_env_file
+    load_ssh_agent
     export RESTIC_PASSWORD=$passphrase
     set +e
     output=$(./restic -r "$repository/auto_conf" cat config 2>&1)

--- a/scripts/config
+++ b/scripts/config
@@ -92,24 +92,6 @@ set__conf() {
     fi
 }
 
-set__on_calendar() {
-    ynh_app_setting_set --key="on_calendar" --value="$on_calendar"
-    ynh_config_add --template="systemd.timer" --destination="/etc/systemd/system/$app.timer"
-    systemctl daemon-reload
-}
-
-set__check_on_calendar() {
-    ynh_app_setting_set --key="check_on_calendar" --value="$check_on_calendar"
-    ynh_config_add --template="systemd_check.timer" --destination="/etc/systemd/system/${app}_check.timer"
-    systemctl daemon-reload
-}
-
-set__check_read_data_on_calendar() {
-    ynh_app_setting_set --key="check_read_data_on_calendar" --value="$check_read_data_on_calendar"
-    ynh_config_add --template="systemd_check_read_data.timer" --destination="/etc/systemd/system/${app}_check_read_data.timer"
-    systemctl daemon-reload
-}
-
 set__forget_policy() {
     ynh_app_setting_set --key="forget_policy" --value="$forget_policy"
 }

--- a/scripts/config
+++ b/scripts/config
@@ -49,6 +49,10 @@ get__conf() {
     ynh_app_setting_get --app=$app --key=conf
 }
 
+get__forget_policy() {
+    ynh_app_setting_get --app=$app --key=forget_policy
+}
+
 #=================================================
 # SPECIFIC VALIDATORS FOR TOML SHORT KEYS
 #=================================================
@@ -84,6 +88,28 @@ set__conf() {
         # Update the config of the app
         ynh_app_setting_set --app=$app --key=conf --value=$conf
     fi
+}
+
+set__on_calendar() {
+    ynh_app_setting_set --key="on_calendar" --value="$on_calendar"
+    ynh_config_add --template="systemd.timer" --destination="/etc/systemd/system/$app.timer"
+    systemctl daemon-reload
+}
+
+set__check_on_calendar() {
+    ynh_app_setting_set --key="check_on_calendar" --value="$check_on_calendar"
+    ynh_config_add --template="systemd_check.timer" --destination="/etc/systemd/system/${app}_check.timer"
+    systemctl daemon-reload
+}
+
+set__check_read_data_on_calendar() {
+    ynh_app_setting_set --key="check_read_data_on_calendar" --value="$check_read_data_on_calendar"
+    ynh_config_add --template="systemd_check_read_data.timer" --destination="/etc/systemd/system/${app}_check_read_data.timer"
+    systemctl daemon-reload
+}
+
+set__forget_policy() {
+    ynh_app_setting_set --key="forget_policy" --value="$forget_policy"
 }
 
 #=================================================

--- a/scripts/config
+++ b/scripts/config
@@ -148,7 +148,7 @@ run__check_connection() {
     pushd "/var/www/$app"
     load_env_file
     load_ssh_agent
-    export RESTIC_PASSWORD="$passphrase"
+    export RESTIC_PASSWORD=$passphrase
     set +e
     output=$(./restic -r "$repository/auto_conf" cat config 2>&1)
     exit_code=$?

--- a/scripts/config
+++ b/scripts/config
@@ -11,15 +11,15 @@ ynh_abort_if_errors
 get__info() {
         cat << EOF
 ask:
-  en: "**Backup state**: ${old[state]}
+  en: "**Backup state**: ${state}
 
-    **Last run**: ${old[last_run]}"
+    **Last run**: ${last_run}"
 EOF
-    if [ "${old[state]}" == "failed" ]; then
+    if [ "${state}" == "failed" ]; then
         cat << EOF
 style: "danger"
 EOF
-    elif [ "${old[state]}" == "successful" ]; then
+    elif [ "${state}" == "successful" ]; then
         cat << EOF
 style: "success"
 EOF
@@ -78,7 +78,9 @@ set__data_multimedia() {
         mkdir -p /home/yunohost.multimedia/
         touch /home/yunohost.multimedia/.nobackup
     else
-        ynh_safe_rm /home/yunohost.multimedia/.nobackup
+        if [ -e /home/yunohost.multimedia/.nobackup ]; then
+            ynh_safe_rm /home/yunohost.multimedia/.nobackup
+        fi
     fi
 }
 
@@ -116,25 +118,25 @@ load_env_file() {
   local env_file="$app/.env"
   if [ -f "$env_file" ]; then
     set -o allexport
-    source "$env_file" || { echo "Erreur : Impossible de charger le fichier d'environnement $env_file" >&2; exit 1; }
+    source "$env_file" || { ynh_print_warn "Erreur : Impossible de charger le fichier d'environnement $env_file" >&2; exit 1; }
     set +o allexport
   fi
 }
 
 load_ssh_agent() {
-  local ssh_key="/root/.ssh/id${$app}ed25519"
+  local ssh_key="/root/.ssh/id_${app}_ed25519"
 
   # Verify if ssh-agent is running, start it otherwise
   if [ -z "${SSH_AGENT_PID:-}" ] || ! ps -p "$SSH_AGENT_PID" > /dev/null 2>&1; then
-    eval "$(ssh-agent -s)" || { echo "Erreur : Impossible de démarrer ssh-agent" >&2; exit 1; }
+    eval "$(ssh-agent -s)" || { ynh_print_warn "Erreur : Impossible de démarrer ssh-agent" >&2; exit 1; }
   fi
 
   # Verify if SSH key is already added
   if ! ssh-add -l | grep -q "$(basename "$ssh_key")"; then
     if [ -f "$ssh_key" ]; then
-      ssh-add "$ssh_key" > /dev/null 2>&1 || echo "Erreur : Impossible d'ajouter la clé SSH $ssh_key" >&2
+      ssh-add "$ssh_key" > /dev/null 2>&1 || ynh_print_warn "Erreur : Impossible d'ajouter la clé SSH $ssh_key" >&2
     else
-      echo "Erreur : Clé SSH $ssh_key introuvable" >&2
+      ynh_print_warn "Erreur : Clé SSH $ssh_key introuvable" >&2
     fi
   fi
   trap 'ssh-agent -k > /dev/null' EXIT
@@ -143,22 +145,24 @@ load_ssh_agent() {
 run__check_connection() {
     local output
     local exit_code
-    ynh_print_info "Checking connection..."
     pushd "/var/www/$app"
     load_env_file
     load_ssh_agent
+    export RESTIC_PASSWORD="$passphrase"
+    set +e
     output=$(./restic -r "$repository/auto_conf" cat config 2>&1)
     exit_code=$?
+    set -e
         case $exit_code in
         0)
-            ynh_print_info "Le dépôt est déjà initialisé."
+            ynh_print_info "Connexion réussie, le dépôt est déjà initialisé."
             ;;
         10)
-            ynh_print_info "Le dépôt n'existe pas (code $exit_code)."
+            ynh_print_info "Connexion réussie, le dépôt n'existe pas encore."
             ;;
         1)
             if [[ "$output" == *"repository does not exist"* ]]; then
-                ynh_print_info "Le dépôt n'existe pas mais la commande n'a pas échoué (ancienne version de Restic ?)."
+                ynh_print_info "Connexion réussie, le dépôt n'existe pas encore."
             else
                 ynh_print_warn "La commande a échoué avec le code $exit_code. Détails : $output"
             fi
@@ -169,7 +173,6 @@ run__check_connection() {
     esac
 
     popd
-    return $exit_code
 }
 
 #=================================================

--- a/scripts/config
+++ b/scripts/config
@@ -94,20 +94,20 @@ run__check_connection() {
     set -e
         case $exit_code in
         0)
-            ynh_print_info "Connexion réussie, le dépôt est déjà initialisé."
+            ynh_print_info "Connection successfull, repository is already initialized."
             ;;
         10)
-            ynh_print_info "Connexion réussie, le dépôt n'existe pas encore."
+            ynh_print_info "Connection successfull, repository does not exists yet."
             ;;
         1)
             if [[ "$output" == *"repository does not exist"* ]]; then
-                ynh_print_info "Connexion réussie, le dépôt n'existe pas encore."
+                ynh_print_info "Connection successfull, repository does not exists yet."
             else
-                ynh_print_warn "La commande a échoué avec le code $exit_code. Détails : $output"
+                ynh_print_warn "Action failed with code $exit_code. Details : $output"
             fi
             ;;
         *)
-            ynh_print_warn "La commande a échoué avec le code $exit_code. Détails : $output"
+            ynh_print_warn "Action failed with code $exit_code. Details : $output"
             ;;
     esac
 

--- a/scripts/config
+++ b/scripts/config
@@ -45,14 +45,6 @@ get__data_multimedia() {
     fi
 }
 
-get__conf() {
-    ynh_app_setting_get --app=$app --key=conf
-}
-
-get__forget_policy() {
-    ynh_app_setting_get --app=$app --key=forget_policy
-}
-
 #=================================================
 # SPECIFIC VALIDATORS FOR TOML SHORT KEYS
 #=================================================
@@ -84,19 +76,11 @@ set__data_multimedia() {
     fi
 }
 
-set__conf() {
-    if [ -n "${conf}" ]
-    then
-        # Update the config of the app
-        ynh_app_setting_set --app=$app --key=conf --value=$conf
-    fi
-}
+#=================================================
+# SPECIFIC ACTIONS FOR TOML SHORT KEY
+#=================================================
 
-set__forget_policy() {
-    ynh_app_setting_set --key="forget_policy" --value="$forget_policy"
-}
-
-load_env_file() {
+__load_env_file() {
   local env_file="$app/.env"
   if [ -f "$env_file" ]; then
     set -o allexport
@@ -105,7 +89,7 @@ load_env_file() {
   fi
 }
 
-load_ssh_agent() {
+__load_ssh_agent() {
   local ssh_key="/root/.ssh/id_${app}_ed25519"
 
   # Verify if ssh-agent is running, start it otherwise
@@ -128,8 +112,8 @@ run__check_connection() {
     local output
     local exit_code
     pushd "/var/www/$app"
-    load_env_file
-    load_ssh_agent
+    __load_env_file
+    __load_ssh_agent
     export RESTIC_PASSWORD=$passphrase
     set +e
     output=$(./restic -r "$repository/auto_conf" cat config 2>&1)
@@ -155,6 +139,10 @@ run__check_connection() {
     esac
 
     popd
+}
+
+run__now() {
+    systemctl start --no-block $app
 }
 
 #=================================================

--- a/scripts/config
+++ b/scripts/config
@@ -112,6 +112,66 @@ set__forget_policy() {
     ynh_app_setting_set --key="forget_policy" --value="$forget_policy"
 }
 
+load_env_file() {
+  local env_file="$app/.env"
+  if [ -f "$env_file" ]; then
+    set -o allexport
+    source "$env_file" || { echo "Erreur : Impossible de charger le fichier d'environnement $env_file" >&2; exit 1; }
+    set +o allexport
+  fi
+}
+
+load_ssh_agent() {
+  local ssh_key="/root/.ssh/id${$app}ed25519"
+
+  # Verify if ssh-agent is running, start it otherwise
+  if [ -z "${SSH_AGENT_PID:-}" ] || ! ps -p "$SSH_AGENT_PID" > /dev/null 2>&1; then
+    eval "$(ssh-agent -s)" || { echo "Erreur : Impossible de démarrer ssh-agent" >&2; exit 1; }
+  fi
+
+  # Verify if SSH key is already added
+  if ! ssh-add -l | grep -q "$(basename "$ssh_key")"; then
+    if [ -f "$ssh_key" ]; then
+      ssh-add "$ssh_key" > /dev/null 2>&1 || echo "Erreur : Impossible d'ajouter la clé SSH $ssh_key" >&2
+    else
+      echo "Erreur : Clé SSH $ssh_key introuvable" >&2
+    fi
+  fi
+  trap 'ssh-agent -k > /dev/null' EXIT
+}
+
+run__check_connection() {
+    local output
+    local exit_code
+    ynh_print_info "Checking connection..."
+    pushd "/var/www/$app"
+    load_env_file
+    load_ssh_agent
+    output=$(./restic -r "$repository/auto_conf" cat config 2>&1)
+    exit_code=$?
+        case $exit_code in
+        0)
+            ynh_print_info "Le dépôt est déjà initialisé."
+            ;;
+        10)
+            ynh_print_info "Le dépôt n'existe pas (code $exit_code)."
+            ;;
+        1)
+            if [[ "$output" == *"repository does not exist"* ]]; then
+                ynh_print_info "Le dépôt n'existe pas mais la commande n'a pas échoué (ancienne version de Restic ?)."
+            else
+                ynh_print_warn "La commande a échoué avec le code $exit_code. Détails : $output"
+            fi
+            ;;
+        *)
+            ynh_print_warn "La commande a échoué avec le code $exit_code. Détails : $output"
+            ;;
+    esac
+
+    popd
+    return $exit_code
+}
+
 #=================================================
 # GENERIC FINALIZATION
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -17,6 +17,10 @@ ynh_app_setting_set --key=check_on_calendar --value="$check_on_calendar"
 check_read_data_on_calendar="Sat *-*-1..7 3:15:00"
 ynh_app_setting_set --key=check_read_data_on_calendar --value="$check_read_data_on_calendar"
 
+# Set default forget policy
+forget_policy="--keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"
+ynh_app_setting_set --key=forget_policy --value="$forget_policy"
+
 ynh_app_setting_set --key=last_run --value="never"
 ynh_app_setting_set --key=state --value="the first backup will be launched soon"
 

--- a/scripts/install
+++ b/scripts/install
@@ -23,6 +23,7 @@ ynh_app_setting_set --key=forget_policy --value="$forget_policy"
 
 ynh_app_setting_set --key=last_run --value="never"
 ynh_app_setting_set --key=state --value="the first backup will be launched soon"
+ynh_app_setting_set --key=backup_core_only --value=0
 
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -60,6 +60,10 @@ chmod u+x "$install_dir/check_method"
 ynh_config_add --template="check-with-restic" --destination="$install_dir/check-with-restic"
 chmod u+x "$install_dir/check-with-restic"
 
+## Helpers
+ynh_config_add --template="helpers" --destination="$install_dir/helpers"
+chmod u+x "$install_dir/helpers"
+
 #=================================================
 # SYSTEM CONFIGURATION
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -70,6 +70,11 @@ if [[ "$last_run" = "" ]]; then
     ynh_app_setting_set --key=last_run --value="never"
 fi
 
+forget_policy=$(ynh_app_setting_get --key=forget_policy)
+if [[ "$forget_policy" = "" ]]; then
+    ynh_app_setting_set --key=forget_policy --value="--keep-daily 7 --keep-weekly 8 --keep-monthly 12"
+fi
+
 #=================================================
 # INSTALL RESTIC
 #=================================================
@@ -106,6 +111,8 @@ ynh_config_add --template="check-with-restic" --destination="$install_dir/check-
 chmod u+x "$install_dir/check-with-restic"
 
 chown -R "$app:$app" "$install_dir"
+
+chmod 600 /root/.ssh/id_${app}_ed25519
 
 #=================================================
 # SYSTEM CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -75,6 +75,8 @@ if [[ "$forget_policy" = "" ]]; then
     ynh_app_setting_set --key=forget_policy --value="--keep-daily 7 --keep-weekly 8 --keep-monthly 12"
 fi
 
+ynh_app_setting_set_default --key=backup_core_only --value=0
+
 #=================================================
 # INSTALL RESTIC
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -116,6 +116,10 @@ chown -R "$app:$app" "$install_dir"
 
 chmod 600 /root/.ssh/id_${app}_ed25519
 
+## Helpers
+ynh_config_add --template="helpers" --destination="$install_dir/helpers"
+chmod u+x "$install_dir/helpers"
+
 #=================================================
 # SYSTEM CONFIGURATION
 #=================================================


### PR DESCRIPTION
## What’s New

- The main log now unifies all logs and errors from sub-processes and scripts (closes #52)
- Users can now define their own retention rules for backups (forget policy) (closes #51)
- A new button allows users to verify their connection to the backup provider before running backups (closes #53)
- Users can now choose to back up only the core system (excluding user data) (closes #45)
- Added comprehensive documentation in both French and English (closes #50 and closes #54)

## Bug Fixes

- Passwords are now masked in logs shared via YunoPaste (closes #48)
- The `exclude:` rule system has been rewritten for greater flexibility and precision (closes #47)
- systemd timers are now fully synchronized with the configuration panel, allowing edits directly from the UI.
- Upgrades now automatically set correct file permissions for private keys (closes #49)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)

## Testing for users

`yunohost app upgrade restic --url https://github.com/YunoHost-Apps/restic_ynh/tree/testing`