### PR TITLE
Filter error log

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Regularly create encrypted backups sent to another server using Restic
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://restic.net)
-[![Version: 0.18.1~ynh2](https://img.shields.io/badge/Version-0.18.1~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/restic/)
+[![Version: 0.18.1~ynh3](https://img.shields.io/badge/Version-0.18.1~ynh3-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/restic/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/restic"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/backup-with-restic
+++ b/conf/backup-with-restic
@@ -91,17 +91,27 @@ done
 # SEND MAIL TO NOTIFY ABOUT FAILED OPERATIONS
 #=============================================
 
-partial_errors="$(grep -iE "Error|Skipped|Warning|Fatal|Fail" "$log_file" | grep -v "backup 'systemctl stop")"
-if [ -n "$partial_errors" ]; then
-    errors+="\nSome backup partially failed:\n$partial_errors"
-fi
+# Détection des erreurs critiques
+critical_errors="$(grep -iE "Error|Skipped|Fatal|Fail" "$log_file")"
+
+# Détection des warnings
+warnings="$(grep -iE "Warning" "$log_file" | grep -v "backup 'systemctl stop")"
 
 # Send mail on backup (partially) failed
 domain=$(hostname)
 repository="$(sudo yunohost app setting __APP__ repository)"
-if [[ -n "$errors" ]]; then
+
+# Si des erreurs critiques sont présentes
+if [ -n "$critical_errors" ]; then
+    errors+="\nSome backup partially failed:\n$critical_errors"
     sudo yunohost app setting __APP__ state -v "failed"
     echo -e "$errors\n\n\n$(cat "$log_file")" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[__APP__] Backup failed from $domain onto $repository" root
+# Si uniquement des warnings sont présents
+elif [ -n "$warnings" ]; then
+    errors+="\nBackup completed with warnings:\n$warnings"
+    sudo yunohost app setting __APP__ state -v "successful_with_warnings"
+    echo -e "$errors\n\n\n$(cat "$log_file")" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[__APP__] Backup completed with warnings from $domain onto $repository" root
+# Si tout s'est bien passé
 else
     sudo yunohost app setting __APP__ state -v "successful"
 fi

--- a/conf/backup-with-restic
+++ b/conf/backup-with-restic
@@ -91,7 +91,7 @@ done
 # SEND MAIL TO NOTIFY ABOUT FAILED OPERATIONS
 #=============================================
 
-partial_errors="$(grep -iE "Error|Skipped|Warning|Fatal|Fail" "$log_file")"
+partial_errors="$(grep -iE "Error|Skipped|Warning|Fatal|Fail" "$log_file" | grep -v "backup 'systemctl stop")"
 if [ -n "$partial_errors" ]; then
     errors+="\nSome backup partially failed:\n$partial_errors"
 fi

--- a/conf/backup-with-restic
+++ b/conf/backup-with-restic
@@ -9,6 +9,11 @@ filter_hooks() {
     ls /usr/share/yunohost/hooks/backup/ | grep "\-$1_" | cut -d"-" -f2 | uniq 2>&1
 }
 
+# Some apps need to be stopped to be backed up
+# https://github.com/search?q=org%3AYunoHost-Apps%20recommended%20to%20make%20your%20backup%20when%20the%20service%20is%20stopped&type=code
+apps_to_stop=("synapse" "gitea" "seafile" "sogo" "monitorix" "xwiki")
+stop_apps=$(sudo yunohost app setting __APP__ stop_apps)
+
 sudo yunohost app setting __APP__ last_run -v "${current_date}"
 sudo yunohost app setting __APP__ state -v "ongoing"
 
@@ -62,6 +67,8 @@ done
 
 # Loop on applications
 for application in $(sudo ls /etc/yunohost/apps/); do
+    stopped="0"
+
     # Exclude/Include logic
     if $include_all; then
         # "All" mode: those in exclude_list are excluded.
@@ -81,9 +88,20 @@ for application in $(sudo ls /etc/yunohost/apps/); do
         continue
     fi
 
+    if [[ " ${apps_to_stop[@]} " =~ " ${application} " ]] && [ "$stop_apps" = "1" ]; then
+        systemctl stop "$application"
+        stopped="1"
+    fi
+
     # Execute backup
     if ! sudo yunohost backup create -n "auto_$application" --method __APP___app --apps "$application" >> "$log_file" 2>&1; then
         errors+="\nThe backup miserably failed to backup $application application."
+    fi
+
+    # Start app if stopped
+    if [[ "$application" == "1" ]]; then
+        systemctl start "$application"
+        stopped="0"
     fi
 done
 

--- a/conf/backup-with-restic
+++ b/conf/backup-with-restic
@@ -113,7 +113,7 @@ done
 critical_errors="$(grep -iE "Error|Skipped|Fatal|Fail" "$log_file")"
 
 # Détection des warnings
-warnings="$(grep -iE "Warning" "$log_file" | grep -v "backup 'systemctl stop")"
+warnings="$(grep -iE "Warning" "$log_file")"
 
 # Send mail on backup (partially) failed
 domain=$(hostname)

--- a/conf/check-with-restic
+++ b/conf/check-with-restic
@@ -86,17 +86,27 @@ done
 # SEND MAIL TO NOTIFY ABOUT FAILED OPERATIONS
 #=============================================
 
-partial_errors="$(grep -iE "Error|Skipped|Warning|Fatal|Fail" "$log_file")"
-if [ -n "$partial_errors" ]; then
-    errors+="\nSome backup checks partially failed:\n$partial_errors"
-fi
+# Détection des erreurs critiques
+critical_errors="$(grep -iE "Error|Skipped|Fatal|Fail" "$log_file")"
+
+# Détection des warnings
+warnings="$(grep -iE "Warning" "$log_file")"
 
 # Send mail on backup (partially) failed
 domain=$(hostname)
 repository="$(sudo yunohost app setting __APP__ repository)"
-if [[ -n "$errors" ]]; then
+
+# Si des erreurs critiques sont présentes
+if [ -n "$critical_errors" ]; then
+    errors+="\nSome backup checks partially failed:\n$critical_errors"
     sudo yunohost app setting __APP__ state -v "failed"
-    echo -e "$errors\n\n\n$(cat "$log_file")" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[__APP__] Backup checks failed from $domain onto $repository" root
+    echo -e "$errors\n\n\n$(cat "$log_file")" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[__APP__] Backup failed from $domain onto $repository" root
+# Si uniquement des warnings sont présents
+elif [ -n "$warnings" ]; then
+    errors+="\nBackup check completed with warnings:\n$warnings"
+    sudo yunohost app setting __APP__ state -v "successful_with_warnings"
+    echo -e "$errors\n\n\n$(cat "$log_file")" | mail -a "Content-Type: text/plain; charset=UTF-8" -s "[__APP__] Backup completed with warnings from $domain onto $repository" root
+# Si tout s'est bien passé
 else
     sudo yunohost app setting __APP__ state -v "successful"
 fi

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -116,6 +116,13 @@ name.fr = "Paramètres de Restic"
         help.fr = "Options Restic forget pour nettoyer les anciennes sauvegardes. Par exemple : --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"
         default = "--keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"
 
+        [main.advanced.stop_apps]
+        ask.en = "Stop apps before backup"
+        ask.fr = "Eteindre les applications avant la sauvegarde"
+        help.en = "Some applications recommand to be stopped to be backed up (Synapse, Gitea, Seafile, Sogo, Monitorix, Xwiki)"
+        help.fr = "Il est recommandé d'éteindre certaines applications avant de les sauvegarder (Synapse, Gitea, Seafile, Sogo, Monitorix, Xwiki)"
+        type = "boolean"
+
     [main.actions]
     name = "Actions"
     optional = true

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -112,15 +112,15 @@ name.fr = "Paramètres de Restic"
         ask.en = "Forget policy for old backups"
         ask.fr = "Politique d'oubli pour les anciennes sauvegardes"
         type = "string"
-        help.en = "Restic forget options to clean up old backups. For example: --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"
-        help.fr = "Options Restic forget pour nettoyer les anciennes sauvegardes. Par exemple : --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"
+        help.en = "Restic forget options to clean up old backups. For example: `--keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2`"
+        help.fr = "Options Restic forget pour nettoyer les anciennes sauvegardes. Par exemple : `--keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2`"
         default = "--keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 2"
 
         [main.advanced.stop_apps]
-        ask.en = "Stop apps before backup"
-        ask.fr = "Eteindre les applications avant la sauvegarde"
+        ask.en = "Stop apps during backup"
+        ask.fr = "Eteindre les applications pendant la sauvegarde"
         help.en = "Some applications recommand to be stopped to be backed up (Synapse, Gitea, Seafile, Sogo, Monitorix, Xwiki)"
-        help.fr = "Il est recommandé d'éteindre certaines applications avant de les sauvegarder (Synapse, Gitea, Seafile, Sogo, Monitorix, Xwiki)"
+        help.fr = "Il est recommandé d'éteindre certaines applications pendant la sauvegarde (Synapse, Gitea, Seafile, Sogo, Monitorix, Xwiki)"
         type = "boolean"
 
     [main.actions]

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -91,3 +91,9 @@ Once the archive is in place, YunoHost will recognize it, and you can proceed wi
 
 - **Backblaze B2 as Remote Repository:**
   When using Backblaze B2, if you do not specify a subfolder, you must still append a `:` to the end of the address. This allows Restic to append the subfolder to the address (e.g., changing `b2:xxxxxxxxxxx:` to `b2:xxxxxxxxxxx:/auto_<app>`). This resolves the error "bucket name contains invalid characters."
+
+- **Make your backup when the service is stopped:**
+  Some YunoHost apps (like Synapse, Gitea, Seafile, Sogo, Monitorix and Xwiki) recommand to make your backup when the service is stopped. You can enable an option in Restic Config Panel to stop them automatically during the backup. If enabled, these apps won't be available for users during each backup.
+
+- **YunoHost Backup Method:**
+  Restic for YunoHost adds a [custom backup method](https://doc.yunohost.org/en/admin/backups/custom_backup_methods/) named `__APP___app`, which replaces the default "local" backup step with sending the backup to a remote server. This method is called for each saved content (configuration, data, media, and each application) as follows: `sudo yunohost backup create -n "auto_$application" --method __APP___app --apps "$application"`. To manually trigger a backup with Restic, we recommend using `systemctl start restic`. This command will automatically use the custom method, applying the configuration you set during installation or in the **Config Panel**. If you use the custom backup method directly, you must specify what you want to back up. The `-n` flag is undocumented but required to determine where your backup will be stored on the remote server.

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,10 +1,10 @@
 ### Command-line usage
 
-- Display the apps list to backup: `yunohost app setting restic apps`
-- Edit the apps list to backup: `yunohost app setting restic apps -v "nextcloud,wordpress"`
-- Trigger a backup manually: `systemctl start restic`
-- Trigger a backup consistency check: `systemctl start restic_check`
-- Trigger a complete check of the backups (this reads all the backed up data, it can take some time): `systemctl start restic_check_read_data`
+- Display the apps list to backup: `yunohost app setting __APP__ apps`
+- Edit the apps list to backup: `yunohost app setting __APP__ apps -v "nextcloud,wordpress"`
+- Trigger a backup manually: `systemctl start __APP__`
+- Trigger a backup consistency check: `systemctl start __APP___check`
+- Trigger a complete check of the backups (this reads all the backed up data, it can take some time): `systemctl start __APP___check_read_data`
 
 ### How to verify if backups succeeded
 
@@ -12,12 +12,12 @@ To verify if your automatic Restic backups succeeded, follow these steps:
 
 First, you need root access to the server. If your repository is not using SFTP, load the Restic environment variables by running:
 ```bash
-source /var/www/restic/.env
+source /var/www/__APP__/.env
 ```
 
 To get the target repository URL used by Restic, run:
 ```bash
-yunohost app setting restic repository
+yunohost app setting __APP__ repository
 ```
 This will return something like:
 ```
@@ -28,7 +28,7 @@ For each YunoHost application, Restic stores backups in a subdirectory of the re
 
 If you're using SFTP, the SSH key is tied to the root user, so you must be logged in as root. For all other repository types (S3, B2, etc.), navigate to the Restic directory:
 ```bash
-cd /var/www/restic/
+cd /var/www/__APP__/
 ```
 Then load the environment variables:
 ```bash
@@ -36,7 +36,7 @@ source .env
 ```
 Set the `RESTIC_REPOSITORY` variable to include the subdirectory for the app you want to check. For example, for Roundcube:
 ```bash
-RESTIC_REPOSITORY=$(yunohost app setting restic repository)/auto_roundcube
+RESTIC_REPOSITORY=$(yunohost app setting __APP__ repository)/auto_roundcube
 ```
 
 To verify the latest backup, list its contents with:
@@ -49,17 +49,17 @@ If the backup succeeded, you'll see a list of files and directories.
 
 To restore a backup using Restic, start by accessing the repository as described in the previous guide. Ensure you're logged in as **root** and, if not using SFTP, load the environment variables:
 ```bash
-source /var/www/restic/.env
+source /var/www/__APP__/.env
 ```
 
 Navigate to the Restic directory:
 ```bash
-cd /var/www/restic/
+cd /var/www/__APP__/
 ```
 
 Set the `RESTIC_REPOSITORY` variable to point to the subdirectory of the app you want to restore. For example, for Roundcube:
 ```bash
-RESTIC_REPOSITORY=$(yunohost app setting restic repository)/auto_roundcube
+RESTIC_REPOSITORY=$(yunohost app setting __APP__ repository)/auto_roundcube
 ```
 
 Next, create a `.tar` archive of the files you want to restore. For example, to restore the latest snapshot:
@@ -96,4 +96,4 @@ Once the archive is in place, YunoHost will recognize it, and you can proceed wi
   Some YunoHost apps (like Synapse, Gitea, Seafile, Sogo, Monitorix and Xwiki) recommand to make your backup when the service is stopped. You can enable an option in Restic Config Panel to stop them automatically during the backup. If enabled, these apps won't be available for users during each backup.
 
 - **YunoHost Backup Method:**
-  Restic for YunoHost adds a [custom backup method](https://doc.yunohost.org/en/admin/backups/custom_backup_methods/) named `__APP___app`, which replaces the default "local" backup step with sending the backup to a remote server. This method is called for each saved content (configuration, data, media, and each application) as follows: `sudo yunohost backup create -n "auto_$application" --method __APP___app --apps "$application"`. To manually trigger a backup with Restic, we recommend using `systemctl start restic`. This command will automatically use the custom method, applying the configuration you set during installation or in the **Config Panel**. If you use the custom backup method directly, you must specify what you want to back up. The `-n` flag is undocumented but required to determine where your backup will be stored on the remote server.
+  Restic for YunoHost adds a [custom backup method](https://doc.yunohost.org/en/admin/backups/custom_backup_methods/) named `__APP___app`, which replaces the default "local" backup step with sending the backup to a remote server. This method is called for each saved content (configuration, data, media, and each application) as follows: `sudo yunohost backup create -n "auto_$application" --method __APP___app --apps "$application"`. To manually trigger a backup with Restic, we recommend using `systemctl start __APP__`. This command will automatically use the custom method, applying the configuration you set during installation or in the **Config Panel**. If you use the custom backup method directly, you must specify what you want to back up. The `-n` flag is undocumented but required to determine where your backup will be stored on the remote server.

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -99,3 +99,9 @@ source /var/www/restic/.env
 
 - **Utilisation de Backblaze B2 comme dépôt distant :**
   Avec Backblaze B2, si vous ne précisez pas de sous-dossier, ajoutez tout de même un `:` à la fin de l’adresse. Cela permet à Restic d’ajouter automatiquement le sous-dossier (par exemple, transformer `b2:xxxxxxxxxxx:` en `b2:xxxxxxxxxxx:/auto_<app>`). Cette étape évite l’erreur *"bucket name contains invalid characters"*.
+
+- **Make your backup when the service is stopped:**
+  Plusieurs applications YunoHost (comme Synapse, Gitea, Seafile, Sogo, Monitorix et Xwiki) recommandent d'effectuer les sauvegardes lorsque le service est à l'arrêt. Vous pouvez activer une option dans le Config Panel de Restic pour les arrêter automatiquement pendant la sauvegarde. Si ce paramètre est activé, ces applications seront indisponibles aux utilisateurs pendant chaque sauvegarde.
+
+- **YunoHost Backup Method:**
+  L'application YunoHost Restic ajoute une [méthode de sauvegarde personnalisée](https://doc.yunohost.org/fr/admin/backups/custom_backup_methods/) nommée `__APP___app` qui permet d'ajouter l'étape d'envoi de la sauvegarde sur un serveur distant à la place de la sauvegarde en "local". Cette méthode est appelée pour chaque contenu sauvegardé (configuration, données, multimédia et chaque application) de la manière suivante : `sudo yunohost backup create -n "auto_$application" --method __APP___app --apps "$application"`. Pour lancer une sauvegarde manuellement avec Restic nous vous recommandons d'utiliser `systemctl start restic` qui utilisera cette méthode par elle-même en appliquant la configuration que vous avez demandée lors de l'installation ou dans le Config Panel. Si vous utilisez la méthode de sauvegarde personnalisée vous-même, vous devez préciser ce que vous souhaitez sauvegarder. L'attribut `-n` n'est pas documenté mais est bien nécessaire pour déterminer ou sera stockée votre sauvegarde sur le serveur distant.

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -1,15 +1,15 @@
 ### Utilisation en ligne de commande
 
 - Afficher la liste des applications à sauvegarder :
-  `yunohost app setting restic apps`
+  `yunohost app setting __APP__ apps`
 - Modifier la liste des applications à sauvegarder :
-  `yunohost app setting restic apps -v "nextcloud,wordpress"`
+  `yunohost app setting __APP__ apps -v "nextcloud,wordpress"`
 - Lancer une sauvegarde manuellement :
-  `systemctl start restic`
+  `systemctl start __APP__`
 - Lancer une vérification de la cohérence des sauvegardes :
-  `systemctl start restic_check`
+  `systemctl start __APP___check`
 - Lancer une vérification complète des sauvegardes (cela lit toutes les données sauvegardées, ce qui peut prendre du temps) :
-  `systemctl start restic_check_read_data`
+  `systemctl start __APP___check_read_data`
 
 ### Comment vérifier si les sauvegardes ont réussi
 
@@ -17,12 +17,12 @@ Pour vérifier si vos sauvegardes automatiques Restic ont réussi, suivez ces é
 
 1. **Accès root** : Vous devez avoir un accès root au serveur. Si votre dépôt n'utilise pas SFTP, chargez les variables d'environnement de Restic en exécutant :
    ```bash
-   source /var/www/restic/.env
+   source /var/www/__APP__/.env
    ```
 
 2. **Récupérer l'URL du dépôt** : Pour obtenir l'URL du dépôt utilisé par Restic, exécutez :
    ```bash
-   yunohost app setting restic repository
+   yunohost app setting __APP__ repository
    ```
    Cela retournera quelque chose comme :
    ```
@@ -35,7 +35,7 @@ Pour vérifier si vos sauvegardes automatiques Restic ont réussi, suivez ces é
    - Si vous utilisez **SFTP**, la clé SSH est liée à l'utilisateur root, vous devez donc être connecté en tant que root.
    - Pour tous les autres types de dépôts (S3, B2, etc.), accédez au répertoire Restic :
      ```bash
-     cd /var/www/restic/
+     cd /var/www/__APP__/
      ```
      Puis chargez les variables d'environnement :
      ```bash
@@ -44,7 +44,7 @@ Pour vérifier si vos sauvegardes automatiques Restic ont réussi, suivez ces é
 
 5. **Vérification d'une sauvegarde spécifique** : Définissez la variable `RESTIC_REPOSITORY` pour inclure le sous-dossier de l'application que vous souhaitez vérifier. Par exemple, pour Roundcube :
    ```bash
-   RESTIC_REPOSITORY=$(yunohost app setting restic repository)/auto_roundcube
+   RESTIC_REPOSITORY=$(yunohost app setting __APP__ repository)/auto_roundcube
    ```
 
 6. **Lister le contenu de la dernière sauvegarde** : Pour vérifier la dernière sauvegarde, listez son contenu avec :
@@ -57,17 +57,17 @@ Pour vérifier si vos sauvegardes automatiques Restic ont réussi, suivez ces é
 
 Pour restaurer une sauvegarde avec Restic, commencez par accéder au dépôt comme décrit précédemment. Assurez-vous d'être connecté en tant que **root** et, si vous n'utilisez pas SFTP, chargez les variables d'environnement :
 ```bash
-source /var/www/restic/.env
+source /var/www/__APP__/.env
 ```
 
 1. **Accéder au répertoire Restic** :
    ```bash
-   cd /var/www/restic/
+   cd /var/www/__APP__/
    ```
 
 2. **Définir le dépôt cible** : Définissez la variable `RESTIC_REPOSITORY` pour pointer vers le sous-dossier de l'application que vous souhaitez restaurer. Par exemple, pour Roundcube :
    ```bash
-   RESTIC_REPOSITORY=$(yunohost app setting restic repository)/auto_roundcube
+   RESTIC_REPOSITORY=$(yunohost app setting __APP__ repository)/auto_roundcube
    ```
 
 3. **Créer une archive `.tar`** : Créez une archive `.tar` des fichiers que vous souhaitez restaurer. Par exemple, pour restaurer le dernier snapshot :
@@ -104,4 +104,4 @@ source /var/www/restic/.env
   Plusieurs applications YunoHost (comme Synapse, Gitea, Seafile, Sogo, Monitorix et Xwiki) recommandent d'effectuer les sauvegardes lorsque le service est à l'arrêt. Vous pouvez activer une option dans le Config Panel de Restic pour les arrêter automatiquement pendant la sauvegarde. Si ce paramètre est activé, ces applications seront indisponibles aux utilisateurs pendant chaque sauvegarde.
 
 - **YunoHost Backup Method:**
-  L'application YunoHost Restic ajoute une [méthode de sauvegarde personnalisée](https://doc.yunohost.org/fr/admin/backups/custom_backup_methods/) nommée `__APP___app` qui permet d'ajouter l'étape d'envoi de la sauvegarde sur un serveur distant à la place de la sauvegarde en "local". Cette méthode est appelée pour chaque contenu sauvegardé (configuration, données, multimédia et chaque application) de la manière suivante : `sudo yunohost backup create -n "auto_$application" --method __APP___app --apps "$application"`. Pour lancer une sauvegarde manuellement avec Restic nous vous recommandons d'utiliser `systemctl start restic` qui utilisera cette méthode par elle-même en appliquant la configuration que vous avez demandée lors de l'installation ou dans le Config Panel. Si vous utilisez la méthode de sauvegarde personnalisée vous-même, vous devez préciser ce que vous souhaitez sauvegarder. L'attribut `-n` n'est pas documenté mais est bien nécessaire pour déterminer ou sera stockée votre sauvegarde sur le serveur distant.
+  L'application YunoHost Restic ajoute une [méthode de sauvegarde personnalisée](https://doc.yunohost.org/fr/admin/backups/custom_backup_methods/) nommée `__APP___app` qui permet d'ajouter l'étape d'envoi de la sauvegarde sur un serveur distant à la place de la sauvegarde en "local". Cette méthode est appelée pour chaque contenu sauvegardé (configuration, données, multimédia et chaque application) de la manière suivante : `sudo yunohost backup create -n "auto_$application" --method __APP___app --apps "$application"`. Pour lancer une sauvegarde manuellement avec Restic nous vous recommandons d'utiliser `systemctl start __APP__` qui utilisera cette méthode par elle-même en appliquant la configuration que vous avez demandée lors de l'installation ou dans le Config Panel. Si vous utilisez la méthode de sauvegarde personnalisée vous-même, vous devez préciser ce que vous souhaitez sauvegarder. L'attribut `-n` n'est pas documenté mais est bien nécessaire pour déterminer ou sera stockée votre sauvegarde sur le serveur distant.

--- a/doc/POST_UPGRADE.d/0.18.1~ynh3.md
+++ b/doc/POST_UPGRADE.d/0.18.1~ynh3.md
@@ -1,0 +1,7 @@
+This update improves Restic integration inside YunoHost systems.
+
+## What’s New
+
+- When backups terminate with warnings and no errors, you'll receive an e-mail saying "Backup completed with warnings" instead of "Some backup partially failed", which was wrong.
+- Some applications recommand to be stopped to be backed up (Synapse, Gitea, Seafile, Sogo, Monitorix, Xwiki). You can chose to stop them automatically during backup. Note that this will make them unavailable for users during a few minutes for each backup.
+- Improved documentation

--- a/doc/POST_UPGRADE.d/0.18.1~ynh3_fr.md
+++ b/doc/POST_UPGRADE.d/0.18.1~ynh3_fr.md
@@ -1,0 +1,7 @@
+Cette mise à jour améliore l'intégration de Restic au sein des systèmes YunoHost.
+
+## Nouveautés
+
+- Lorsque la sauvegarde se termine avec des warnings et sans erreurs, vous recevrez un mail ayant comme intitulé "Backup completed with warnings" à la place de "Some backup partially failed" qui induisait en erreur.
+- Certaines applications recommandent d'être éteintes pendant leur sauvegarde (Synapse, Gitea, Seafile, Sogo, Monitorix, Xwiki). Vous pouvez désormais choisir de les éteindre automatiquement pendant leur sauvegarde. Notez que cela les rendra inaccessibles aux utilisateurs pendant quelques minutes, à chaque sauvegarde.
+- Amélioration de la documentation

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Restic"
 description.en = "Regularly create encrypted backups sent to another server using Restic"
 description.fr = "Créez régulièrement des sauvegardes chiffrées envoyées sur un autre serveur avec Restic"
 
-version = "0.18.1~ynh2"
+version = "0.18.1~ynh3"
 
 maintainers = ["Gildas-GH"]
 

--- a/scripts/config
+++ b/scripts/config
@@ -20,6 +20,10 @@ EOF
         cat << EOF
 style: "danger"
 EOF
+    elif [ "${state}" == "successful_with_warnings" ]; then
+        cat << EOF
+style: "warning"
+EOF
     elif [ "${state}" == "successful" ]; then
         cat << EOF
 style: "success"

--- a/scripts/install
+++ b/scripts/install
@@ -24,6 +24,7 @@ ynh_app_setting_set --key=forget_policy --value="$forget_policy"
 ynh_app_setting_set --key=last_run --value="never"
 ynh_app_setting_set --key=state --value="the first backup will be launched soon"
 ynh_app_setting_set --key=backup_core_only --value=0
+ynh_app_setting_set --key=stop_apps --value=0
 
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -75,6 +75,7 @@ if [[ "$forget_policy" = "" ]]; then
     ynh_app_setting_set --key=forget_policy --value="--keep-daily 7 --keep-weekly 8 --keep-monthly 12"
 fi
 
+ynh_app_setting_set_default --key=stop_apps --value=0
 ynh_app_setting_set_default --key=backup_core_only --value=0
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -84,7 +84,7 @@ ynh_app_setting_set_default --key=backup_core_only --value=0
 ynh_script_progression "Installing Restic..."
 
 ynh_setup_source --source_id=main --dest_dir="$install_dir"
-bunzip2 -d -f /var/www/restic/restic.bz2
+bunzip2 -d -f "$install_dir/restic.bz2"
 chmod +x "$install_dir/restic"
 
 # This function will only create it if required


### PR DESCRIPTION
## Changes

- When backups terminate with warnings and no errors, you'll receive an e-mail saying "Backup completed with warnings" instead of "Some backup partially failed", which was wrong.
- Some applications recommand to be stopped to be backed up (Synapse, Gitea, Seafile, Sogo, Monitorix, Xwiki). You can chose to stop them automatically during backup. Note that this will make them unavailable for users during a few minutes for each backup.
- Improved documentation